### PR TITLE
Ticket/dm 40159

### DIFF
--- a/doc/comClassUML.txt
+++ b/doc/comClassUML.txt
@@ -1,3 +1,5 @@
+# Copy and paste the following into http://www.plantuml.com/plantuml/uml/
+
 @startuml
 class Config
 class ComServer
@@ -22,11 +24,13 @@ NetCommand : Children vary in action() and json parameters
 class NCmdAck
 class NCmdNoAck
 class NCmdEcho
+class NCmdSwitchCommandSource
 
 NetCommandException <.. NetCommand : throws
 NetCommand <|-- NCmdAck
 NetCommand <|-- NCmdNoAck
 NetCommand <|-- NCmdEcho
+NetCommand <|-- NCmdSwitchCommandSource
 
 NetCommandException <.. NetCommandFactory : throws
 

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,4 +1,5 @@
 # Version History
+
 0.3.1
 
  - Added welcome message and some basic communication. 

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,4 +1,8 @@
 # Version History
+0.3.1
+
+ - Added welcome message and some basic communication. 
+
 0.3.0
 
  - Added Thread to read tel_elevation.

--- a/serverMain/main.cpp
+++ b/serverMain/main.cpp
@@ -53,9 +53,6 @@ int main(int argc, char* argv[]) {
     system::Config::setup(cfgPath + "m2cellCfg.yaml");
     system::Config& sysCfg = system::Config::get();
 
-    // Setup global items.
-    system::Globals::setup();
-
     // Setup logging
     string logFileName = sysCfg.getLogFileName();
     int logFileSizeMB = sysCfg.getLogFileSizeMB();
@@ -69,6 +66,9 @@ int main(int argc, char* argv[]) {
     log.setOutputDest(util::Log::SPEEDLOG);
     // FUTURE: DM-39974 add command line argument to turn `Log::_alwaysFlush` off.
     log.setAlwaysFlush(true); // spdlog is highly prone to waiting a long time before writing to disk.
+
+    // Setup global items.
+    system::Globals::setup(sysCfg);
 
     // Setup a simple signal handler to handle when clients closing connection results in SIGPIPE.
     signal(SIGPIPE, signalHandler);

--- a/serverMain/main.cpp
+++ b/serverMain/main.cpp
@@ -23,6 +23,7 @@
 #include "system/ComControl.h"
 #include "system/ComControlServer.h"
 #include "system/Config.h"
+#include "system/Globals.h"
 #include "system/TelemetryCom.h"
 #include "system/TelemetryMap.h"
 #include "util/Log.h"
@@ -51,6 +52,9 @@ int main(int argc, char* argv[]) {
     string cfgPath = system::Config::getEnvironmentCfgPath("./configs");
     system::Config::setup(cfgPath + "m2cellCfg.yaml");
     system::Config& sysCfg = system::Config::get();
+
+    // Setup global items.
+    system::Globals::setup();
 
     // Setup logging
     string logFileName = sysCfg.getLogFileName();

--- a/src/LSST/control/NetCommand.cpp
+++ b/src/LSST/control/NetCommand.cpp
@@ -42,7 +42,7 @@ NetCommand::NetCommand(JsonPtr const& inJson_) : inJson(inJson_) {
     }
     try {
         _name = inJson->at("id");
-        _seqId = inJson->at("seq_id");
+        _seqId = inJson->at("sequence_id");
         LDEBUG("NetCommand constructor id=", " seqId=", _seqId);
     } catch (json::exception const& ex) {
         string eMsg = string("NetCommand constructor error in ") + inJson->dump() + " what=" + ex.what();
@@ -50,9 +50,9 @@ NetCommand::NetCommand(JsonPtr const& inJson_) : inJson(inJson_) {
         throw NetCommandException(ERR_LOC, eMsg);
     }
 
-    ackJson["seq_id"] = _seqId;
+    ackJson["sequence_id"] = _seqId;
     ackJson["user_info"] = string("invalid:") + _name;
-    respJson["seq_id"] = _seqId;
+    respJson["sequence_id"] = _seqId;
 }
 
 NetCommand::JsonPtr NetCommand::parse(string const& inStr) {
@@ -66,13 +66,13 @@ NetCommand::JsonPtr NetCommand::parse(string const& inStr) {
         throw NetCommandException(ERR_LOC, eMsg);
     }
     LDEBUG("NetCommand::parse inStr=", inStr, "\njson=", inJson->dump(2));
-    // All commands must have at least id and seq_id
+    // All commands must have at least id and sequence_id
     try {
         string id = inJson->at("id");
-        uint64_t seqId = inJson->at("seq_id");
+        uint64_t seqId = inJson->at("sequence_id");
         LDEBUG("NetCommand::parse id=", id, " seq=", seqId);
     } catch (json::exception const& ex) {
-        string eMsg = string("NetCommand::parse error missing id or seq_id in ") + inJson->dump() +
+        string eMsg = string("NetCommand::parse error missing id or sequence_id in ") + inJson->dump() +
                       " what=" + ex.what();
         LERROR(eMsg);
         throw NetCommandException(ERR_LOC, eMsg);

--- a/src/LSST/control/NetCommand.h
+++ b/src/LSST/control/NetCommand.h
@@ -51,7 +51,7 @@ public:
 ///
 /// The children of this class can be created from a `json` object
 /// where the "id" defines which child class will be used. "id"
-/// and "seq_id" are the only parameters expected in all `json`
+/// and "sequence_id" are the only parameters expected in all `json`
 /// objects. The child classes may require other keys be set.
 /// They should set `ackJson["id"] = "ack";` after all expected
 /// items have been parsed successfully, and throw
@@ -84,7 +84,7 @@ public:
 
     /// Try to parse inStr and return a json object.
     /// @return a json object if `inStr` contains at least
-    ///     a valid "id" and "seq_id".
+    ///     a valid "id" and "sequence_id".
     /// @throw NetCommandException if there are issues with parsing
     ///     `inStr`
     static JsonPtr parse(std::string const& inStr);
@@ -129,7 +129,7 @@ public:
 
 protected:
     /// Protected to ensure proper construction of enable_shared_From_this object.
-    /// @param json must contain "id" and "seq_id" fields.
+    /// @param json must contain "id" and "sequence_id" fields.
     NetCommand(JsonPtr const& json);
 
     /// Execute the action this particular NetCommand needs to take.
@@ -146,9 +146,9 @@ protected:
     NetCommand() = default;
     JsonPtr inJson;  ///< json representation of the received command.
     /// json used to create return ack.
-    nlohmann::json ackJson = {{"id", "noack"}, {"seq_id", 0}, {"user_info", ""}};
+    nlohmann::json ackJson = {{"id", "noack"}, {"sequence_id", 0}, {"user_info", ""}};
     /// json used to create the final response
-    nlohmann::json respJson = {{"id", "fail"}, {"seq_id", 0}, {"user_info", ""}};
+    nlohmann::json respJson = {{"id", "fail"}, {"sequence_id", 0}, {"user_info", ""}};
 
 private:
     std::string _name = "none";  ///< Name of the command as parsed from `inJson`.
@@ -157,7 +157,7 @@ private:
 
 /// NetCommand to simply respond with an ack, and a success.
 /// This class is meant to be useful for testing and diagnostics.
-/// id and seq_id are the only json parameters expected.
+/// id and sequence_id are the only json parameters expected.
 ///
 /// unit test: test_NetCommand.cpp
 class NCmdAck : public NetCommand {
@@ -193,7 +193,7 @@ private:
 /// This class is used to respond to NetCommand requests
 /// that have an error in the initial request. This
 /// includes unknown commands, missing parameters,
-/// and seq_id issues. This command can be added to
+/// and sequence_id issues. This command can be added to
 /// a NetCommandFactory, but it will always respond
 /// with "noack" and then "fail".
 ///

--- a/src/LSST/control/NetCommandDefs.cpp
+++ b/src/LSST/control/NetCommandDefs.cpp
@@ -1,0 +1,71 @@
+/*
+ *  This file is part of LSST M2 support system package.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "control/NetCommandDefs.h"
+
+// System headers
+
+// Third party headers
+
+// Project headers
+#include "system/Globals.h"
+#include "util/Log.h"
+
+using namespace std;
+using json = nlohmann::json;
+
+namespace LSST {
+namespace m2cellcpp {
+namespace control {
+
+
+NCmdSwitchCommandSource::Ptr NCmdSwitchCommandSource::create(JsonPtr const& inJson_) {
+    auto cmd = Ptr(new NCmdSwitchCommandSource(inJson_));
+    return cmd;
+}
+
+NCmdSwitchCommandSource::NCmdSwitchCommandSource(JsonPtr const& inJson) : NetCommand(inJson) {
+    try {
+        _isRemote = inJson->at("isRemote");
+        LDEBUG("NCmdSwitchCommandSource seqId=", getSeqId(), " isRemote=", _isRemote);
+    } catch (json::exception const& ex) {
+        string eMsg = string("NCmdEcho constructor error in ") + inJson->dump() + " what=" + ex.what();
+        LERROR(eMsg);
+        throw NetCommandException(ERR_LOC, eMsg);
+    }
+
+    ackJson["id"] = "ack";
+    ackJson["user_info"] = "switchCommandSource " + to_string(_isRemote);
+}
+
+NetCommand::Ptr NCmdSwitchCommandSource::createNewNetCommand(JsonPtr const& inJson) {
+    NCmdSwitchCommandSource::Ptr cmd = NCmdSwitchCommandSource::create(inJson);
+    return cmd;
+}
+
+bool NCmdSwitchCommandSource::action() {
+    return system::Globals::get().setCommandSourceIsRemote(_isRemote);
+}
+
+}  // namespace control
+}  // namespace m2cellcpp
+}  // namespace LSST

--- a/src/LSST/control/NetCommandDefs.h
+++ b/src/LSST/control/NetCommandDefs.h
@@ -1,0 +1,74 @@
+/*
+ *  This file is part of LSST M2 support system package.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+#ifndef LSST_M2CELLCPP_CONTROL_NETCOMMANDDEFS_H
+#define LSST_M2CELLCPP_CONTROL_NETCOMMANDDEFS_H
+
+// System headers
+
+
+// Third party headers
+
+// Project headers
+#include "control/NetCommand.h"
+
+namespace LSST {
+namespace m2cellcpp {
+namespace control {
+
+/// This class sends back the `inJson["msg"]` value in `respJson["msg"]`.
+/// `inJson["msg"]` is a required field for this command.
+/// Expected message form is: {"isRemote": true, "id": "cmd_switchCommandSource", "sequence_id": 123}
+///
+/// unit test: test_NetCommand.cpp
+class NCmdSwitchCommandSource : public NetCommand {
+public:
+    using Ptr = std::shared_ptr<NCmdSwitchCommandSource>;
+
+    /// @return a new NCmdSwitchCommandSource object based on inJson.
+    static Ptr create(JsonPtr const& inJson);
+
+    virtual ~NCmdSwitchCommandSource() = default;
+
+    /// @return a version of NCmdAck to be used to generate commands.
+    static Ptr createFactoryVersion() { return Ptr(new NCmdSwitchCommandSource()); }
+
+    /// @return the name of the command this specific class handles.
+    std::string getCommandName() const override { return "cmd_switchCommandSource"; }
+
+    /// @return a new NCmdNoAck object using the parameters in 'inJson'
+    NetCommand::Ptr createNewNetCommand(JsonPtr const& inJson) override;
+
+protected:
+    // NCmdNoAck always fails
+    bool action() override;
+
+private:
+    NCmdSwitchCommandSource(JsonPtr const& json);
+    NCmdSwitchCommandSource() : NetCommand() {}
+
+    bool _isRemote = 1; ///< Value of "isRemote" section of message.
+};
+
+}  // namespace control
+}  // namespace m2cellcpp
+}  // namespace LSST
+
+#endif  // LSST_M2CELLCPP_CONTROL_NETCOMMANDDEFS_H

--- a/src/LSST/control/NetCommandFactory.cpp
+++ b/src/LSST/control/NetCommandFactory.cpp
@@ -55,15 +55,15 @@ void NetCommandFactory::addNetCommand(NetCommand::Ptr const& cmd) {
 NetCommand::Ptr NetCommandFactory::getCommandFor(std::string const& jsonStr) {
     auto inJson = NetCommand::parse(jsonStr);
     lock_guard<mutex> lg(_mtx);
-    // If parse didn't throw, there must be a valid id and seq_id.
+    // If parse didn't throw, there must be a valid id and sequence_id.
     string cmdId = inJson->at("id");
-    uint64_t seqId = inJson->at("seq_id");
+    uint64_t seqId = inJson->at("sequence_id");
     NetCommand::Ptr cmdOut;
     // Check if seqId is valid (must be larger than the previous one)
     if (seqId <= _prevSeqId) {
-        string badSeqId = string("Bad seq_id ") + to_string(seqId) + " " + cmdId + " previous seq_id was " +
+        string badSeqId = string("Bad sequence_id ") + to_string(seqId) + " " + cmdId + " previous sequence_id was " +
                           to_string(_prevSeqId);
-        LWARN("getCommandFor seq_id ", seqId, " ", cmdId, badSeqId, " returning ",
+        LWARN("getCommandFor sequence_id ", seqId, " ", cmdId, badSeqId, " returning ",
               _defaultNoAck->getCommandName());
         cmdOut = _defaultNoAck->createNewNetCommand(inJson);
         cmdOut->setAckUserInfo(badSeqId);
@@ -99,7 +99,7 @@ NetCommand::Ptr NetCommandFactory::getNoAck() {
     NetCommand::JsonPtr inJson = std::shared_ptr<nlohmann::json>(new nlohmann::json());
     nlohmann::json& js = *inJson;
     js["id"] = "noack";  // This will be overwritten by the default.
-    js["seq_id"] = 0;
+    js["sequence_id"] = 0;
     auto cmdOut = _defaultNoAck->createNewNetCommand(inJson);
     cmdOut->setAckUserInfo("factory default noack");
     return cmdOut;

--- a/src/LSST/control/NetCommandFactory.h
+++ b/src/LSST/control/NetCommandFactory.h
@@ -60,7 +60,7 @@ public:
 
     /// Get the NetCommand appropriate for the jsonStr.
     /// @return Appropriate NetCommand. _defaultNoAck is returned on
-    ///         unknown commands that have a parsable id and seq_id.
+    ///         unknown commands that have a parsable id and sequence_id.
     /// @throws NetCommandException if there are any problems.
     NetCommand::Ptr getCommandFor(std::string const& jsonStr);
 

--- a/src/LSST/system/ComClient.cpp
+++ b/src/LSST/system/ComClient.cpp
@@ -22,6 +22,9 @@
 // Class header
 #include "system/ComClient.h"
 
+// Third party headers
+#include "nlohmann/json.hpp"
+
 // Project headers
 #include "util/Log.h"
 
@@ -92,6 +95,28 @@ string ComClient::readCommand() {
     // Remove the entire message, including delimiter, from _readStream so the next message is clean.
     _readStream.consume(xfer);
     return outStr;
+}
+
+int ComClient::readWelcomeMsg() {
+    string lastMsgId("configurationFiles");
+    int count = 0;
+    bool done = false;
+    while (!done) {
+        string inMsg = readCommand();
+        try {
+            nlohmann::json js = nlohmann::json::parse(inMsg);
+            string id = js["id"];
+            ++count;
+            LDEBUG("readWelcomeMsg count=", count, " ", inMsg);
+            if (id == lastMsgId) {
+                done = true;
+            }
+        } catch (nlohmann::json::parse_error const& ex) {
+            LERROR("json parse error msg=", ex.what());
+            return -1;
+        }
+    }
+    return count;
 }
 
 }  // namespace system

--- a/src/LSST/system/ComClient.h
+++ b/src/LSST/system/ComClient.h
@@ -59,6 +59,10 @@ public:
     /// @throw boost::system::system_error on other errors.
     std::string readCommand();
 
+    /// Return the number of entries read in the welcome message.
+    ///  A negative value indicates failure.
+    int readWelcomeMsg();
+
     /// Close the connection.
     void close();
 

--- a/src/LSST/system/ComConnection.cpp
+++ b/src/LSST/system/ComConnection.cpp
@@ -158,13 +158,7 @@ void ComConnection::_sendWelcomeMsg() {
         _syncWrite(to_string(js));
     }
 
-    // FUTURE: Currently unsure what these messages are supposed to look like.
-    // if self._is_csc:
-    //     await self._message_event.write_detailed_state(DetailedState.PublishOnly)
-    //     await asyncio.sleep(0.01)
-    //     await self._message_event.write_detailed_state(DetailedState.Available)
-    // summary_state = salobj.State.OFFLINE if self._is_csc else salobj.State.STANDBY
-    // await self._message_event.write_summary_state(summary_state)
+    // FUTURE: This is only for backward compatibility and will not be needed if the final version
     {
         json js;
         js["id"] = "summaryState";
@@ -195,26 +189,6 @@ void ComConnection::_sendWelcomeMsg() {
     // await self._message_event.write_config()
     // TODO: It looks like all of these values should come out of the configuration PLACEHOLDER DM-40317
     // FUTURE: Also, can the gui (and future systems) be capable of handling a dump of the entire config in the json msg? Probably useful.
-    // {'id': 'config',
-    // 'configuration': 'Configurable_File_Description_20180831T092556_surrogate_handling.csv',
-    // 'version': '20180831T092556',
-    // 'controlParameters': 'CtrlParameterFiles_2018-07-19_104314_surg',
-    // 'lutParameters': 'FinalHandlingLUTs',
-    // 'powerWarningMotor': 5.0,
-    // 'powerFaultMotor': 10.0,
-    // 'powerThresholdMotor': 20.0,
-    // 'powerWarningComm': 5.0,
-    // 'powerFaultComm': 10.0,
-    // 'powerThresholdComm': 10.0,
-    // 'inPositionAxial': 0.158,
-    // 'inPositionTangent': 1.1,
-    // 'inPositionSample': 1.0,
-    // 'timeoutSal': 15.0,
-    // 'timeoutCrio': 1.0,
-    // 'timeoutIlc': 3,
-    // 'inclinometerDelta': 2.0,
-    // 'inclinometerDiffEnabled': True,
-    // 'cellTemperatureDelta': 2.0}
     {
         json js;
         js["id"] = "config";

--- a/src/LSST/system/ComConnection.cpp
+++ b/src/LSST/system/ComConnection.cpp
@@ -78,7 +78,7 @@ ComConnection::~ComConnection() { shutdown(); }
 void ComConnection::_syncWrite(string const& msg) {
     size_t bytesWritten = 0;
     LDEBUG("ComConnection::_syncWrite ", msg);
-    while (bytesWritten != msg.length()) {
+    while (bytesWritten < msg.length()) {
         size_t bytesToSend = msg.length() - bytesWritten;
         bytesWritten += _socket.write_some(boost::asio::buffer(msg.c_str() + bytesWritten, bytesToSend));
     }
@@ -105,12 +105,12 @@ void ComConnection::_sendWelcomeMsg() {
 
     Globals& globals = Globals::get();
 
-    // &&& send tcp connected message
+    // send tcp connected message
     {
         json js;
         js["id"] = "tcpIpConnected";
         js["isConnected"] = globals.getTcpIpConnected();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // FUTURE: Setting to true to make the gui happy, not sure what the real conditions are.
@@ -118,76 +118,75 @@ void ComConnection::_sendWelcomeMsg() {
         json js;
         js["id"] = "commandableByDDS";
         js["state"] = globals.getCommandableByDds();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
-    // &&& send hardpoint information mock_server.py:281 await self._message_event.write_hardpoint_list(hardpoints)
+    // send hardpoint information mock_server.py:281 await self._message_event.write_hardpoint_list(hardpoints)
     {
         json js;
         js["id"] = "hardpointList";
         js["actuators"] = globals.getHardPointList();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
-    // &&& send interlock mock_server.py:283 await self._message_event.write_interlock(False)
+    // send interlock mock_server.py:283 await self._message_event.write_interlock(False)
     {
         json js;
         js["id"] = "interlock";
         js["state"] = globals.getInterlock();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
-    // &&& elev external source  mock_server.py:290 await self._message_event.write_inclination_telemetry_source(is_external_source)
+    // elev external source  mock_server.py:290 await self._message_event.write_inclination_telemetry_source(is_external_source)
     {
         json js;
         js["id"] = "inclinationTelemetrySource";
         js["source"] = globals.getTelemetrySource();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
-    // &&& temp offset mock_server.py:292 await self._message_event.write_temperature_offset(
+    // temp offset mock_server.py:292 await self._message_event.write_temperature_offset(
     {
         json js;
         js["id"] = "temperatureOffset";
         js["ring"] = globals.getTemperatureOffsetsRing();
         js["intake"] = globals.getTemperatureOffsetsIntake();
         js["exhaust"] = globals.getTemperatureOffsetsExhaust();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // FUTURE: Currently unsure what these messages are supposed to look like.
-    // &&& if self._is_csc:
-    // &&&     await self._message_event.write_detailed_state(DetailedState.PublishOnly)
-    // &&&     await asyncio.sleep(0.01)
-    // &&&     await self._message_event.write_detailed_state(DetailedState.Available)
-
-    // &&& summary_state = salobj.State.OFFLINE if self._is_csc else salobj.State.STANDBY
-    // &&& await self._message_event.write_summary_state(summary_state)
+    // if self._is_csc:
+    //     await self._message_event.write_detailed_state(DetailedState.PublishOnly)
+    //     await asyncio.sleep(0.01)
+    //     await self._message_event.write_detailed_state(DetailedState.Available)
+    // summary_state = salobj.State.OFFLINE if self._is_csc else salobj.State.STANDBY
+    // await self._message_event.write_summary_state(summary_state)
     {
         json js;
         js["id"] = "summaryState";
         js["summaryState"] = globals.getSummaryState();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
-    // &&& # Send the digital input and output
-    // &&& digital_input = self.model.get_digital_input()
-    // &&& await self._message_event.write_digital_input(digital_input)
+    // # Send the digital input and output
+    // digital_input = self.model.get_digital_input()
+    // await self._message_event.write_digital_input(digital_input)
     {
         json js;
         js["id"] = "digitalInput";
         js["value"] = globals.getDigitalInput();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
 
-    // &&& digital_output = self.model.get_digital_output()
-    // &&& await self._message_event.write_digital_output(digital_output)
+    // digital_output = self.model.get_digital_output()
+    // await self._message_event.write_digital_output(digital_output)
     {
         json js;
         js["id"] = "digitalOutput";
         js["value"] = globals.getDigitalOutput();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // &&& await self._message_event.write_config()
@@ -235,7 +234,7 @@ void ComConnection::_sendWelcomeMsg() {
         js["inclinometerDelta"] = 2.0;
         js["inclinometerDiffEnabled"] = true;
         js["cellTemperatureDelta"] = 2.0;
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // &&& await self._message_event.write_closed_loop_control_mode(
@@ -245,7 +244,7 @@ void ComConnection::_sendWelcomeMsg() {
         json js;
         js["id"] = "closedLoopControlMode";
         js["mode"] = globals.getClosedLoopControlMode();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // &&& await self._message_event.write_enabled_faults_mask(
@@ -255,7 +254,7 @@ void ComConnection::_sendWelcomeMsg() {
         json js;
         js["id"] = "enabledFaultsMask";
         js["mode"] = globals.getEnabledFaultMask();
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 
     // &&& await self._message_event.write_configuration_files()
@@ -267,7 +266,7 @@ void ComConnection::_sendWelcomeMsg() {
                        "Configurable_File_Description_PLACEHOLDER_M2_handling.csv",
                        "Configurable_File_Description_PLACEHOLDER_surrogate_optical.csv",
                        "Configurable_File_Description_PLACEHOLDER_surrogate_handling.csv"};
-        _syncWrite(js);
+        _syncWrite(to_string(js));
     }
 }
 

--- a/src/LSST/system/ComConnection.cpp
+++ b/src/LSST/system/ComConnection.cpp
@@ -66,7 +66,9 @@ namespace system {
 
 ComConnection::Ptr ComConnection::create(IoContextPtr const& ioContext, uint64_t connId,
                                          shared_ptr<ComServer> const& server) {
-    return ComConnection::Ptr(new ComConnection(ioContext, connId, server));
+    auto ptr =  ComConnection::Ptr(new ComConnection(ioContext, connId, server));
+
+    return ptr;
 }
 
 ComConnection::ComConnection(IoContextPtr const& ioContext, uint64_t connId,
@@ -75,7 +77,8 @@ ComConnection::ComConnection(IoContextPtr const& ioContext, uint64_t connId,
 
 ComConnection::~ComConnection() { shutdown(); }
 
-void ComConnection::_syncWrite(string const& msg) {
+void ComConnection::_syncWrite(string const& inMsg) {
+    string msg = inMsg + getDelimiter();
     size_t bytesWritten = 0;
     LDEBUG("ComConnection::_syncWrite ", msg);
     while (bytesWritten < msg.length()) {
@@ -189,9 +192,9 @@ void ComConnection::_sendWelcomeMsg() {
         _syncWrite(to_string(js));
     }
 
-    // &&& await self._message_event.write_config()
-    // TODO: It looks like all of these values should come out of the configuration PLACEHOLDER DM-&&&
-    //       Also, can the gui, and future systems be capable of handling a dump of the entire config in the json msg? Probably useful.
+    // await self._message_event.write_config()
+    // TODO: It looks like all of these values should come out of the configuration PLACEHOLDER DM-40317
+    // FUTURE: Also, can the gui (and future systems) be capable of handling a dump of the entire config in the json msg? Probably useful.
     // {'id': 'config',
     // 'configuration': 'Configurable_File_Description_20180831T092556_surrogate_handling.csv',
     // 'version': '20180831T092556',
@@ -237,9 +240,7 @@ void ComConnection::_sendWelcomeMsg() {
         _syncWrite(to_string(js));
     }
 
-    // &&& await self._message_event.write_closed_loop_control_mode(
-    // &&&     ClosedLoopControlMode.Idle
-    // &&& )
+    // await self._message_event.write_closed_loop_control_mode( ClosedLoopControlMode.Idle )
     {
         json js;
         js["id"] = "closedLoopControlMode";
@@ -247,9 +248,7 @@ void ComConnection::_sendWelcomeMsg() {
         _syncWrite(to_string(js));
     }
 
-    // &&& await self._message_event.write_enabled_faults_mask(
-    // &&&     self.model.error_handler.enabled_faults_mask
-    // &&& )
+    // await self._message_event.write_enabled_faults_mask( self.model.error_handler.enabled_faults_mask )
     {
         json js;
         js["id"] = "enabledFaultsMask";
@@ -257,7 +256,8 @@ void ComConnection::_sendWelcomeMsg() {
         _syncWrite(to_string(js));
     }
 
-    // &&& await self._message_event.write_configuration_files()
+    // await self._message_event.write_configuration_files()
+    // FUTURE: These files need to be located and added to this project DM-40317
     // PLACEHOLDER
     {
         json js;

--- a/src/LSST/system/ComConnection.cpp
+++ b/src/LSST/system/ComConnection.cpp
@@ -31,14 +31,18 @@
 #include <stdexcept>
 
 // Third party headers
+#include "nlohmann/json.hpp"
 
 // Project headers
 #include "system/ComServer.h"
 #include "system/Config.h"
+#include "system/Globals.h"
 #include "util/Log.h"
 
 using namespace std;
 using namespace std::placeholders;
+
+using json = nlohmann::json;
 
 namespace {
 
@@ -71,7 +75,201 @@ ComConnection::ComConnection(IoContextPtr const& ioContext, uint64_t connId,
 
 ComConnection::~ComConnection() { shutdown(); }
 
-void ComConnection::beginProtocol() { _receiveCommand(); }
+void ComConnection::_syncWrite(string const& msg) {
+    size_t bytesWritten = 0;
+    LDEBUG("ComConnection::_syncWrite ", msg);
+    while (bytesWritten != msg.length()) {
+        size_t bytesToSend = msg.length() - bytesWritten;
+        bytesWritten += _socket.write_some(boost::asio::buffer(msg.c_str() + bytesWritten, bytesToSend));
+    }
+
+}
+
+void ComConnection::beginProtocol() {
+    // FUTURE:? This likely needs to indicate there's at least one active ComConnection
+    //          which is slightly tricky as ComConnection can exist for a while after they
+    //          are dead. How important is this?
+    _connectionActive = true;
+    Globals::get().setTcpIpConnected(true); // This seems a bit early to set this, but it's what the gui expects.
+    _sendWelcomeMsg();
+    _receiveCommand();
+}
+
+void ComConnection::_sendWelcomeMsg() {
+    if (!_doSendWelcomeMsg) {
+        return;
+    }
+
+    // Send a bunch of one-time messages that indicate various system states.
+    // Seems like this should happen at telemetry startup.
+
+    Globals& globals = Globals::get();
+
+    // &&& send tcp connected message
+    {
+        json js;
+        js["id"] = "tcpIpConnected";
+        js["isConnected"] = globals.getTcpIpConnected();
+        _syncWrite(js);
+    }
+
+    // FUTURE: Setting to true to make the gui happy, not sure what the real conditions are.
+    {
+        json js;
+        js["id"] = "commandableByDDS";
+        js["state"] = globals.getCommandableByDds();
+        _syncWrite(js);
+    }
+
+    // &&& send hardpoint information mock_server.py:281 await self._message_event.write_hardpoint_list(hardpoints)
+    {
+        json js;
+        js["id"] = "hardpointList";
+        js["actuators"] = globals.getHardPointList();
+        _syncWrite(js);
+    }
+
+    // &&& send interlock mock_server.py:283 await self._message_event.write_interlock(False)
+    {
+        json js;
+        js["id"] = "interlock";
+        js["state"] = globals.getInterlock();
+        _syncWrite(js);
+    }
+
+    // &&& elev external source  mock_server.py:290 await self._message_event.write_inclination_telemetry_source(is_external_source)
+    {
+        json js;
+        js["id"] = "inclinationTelemetrySource";
+        js["source"] = globals.getTelemetrySource();
+        _syncWrite(js);
+    }
+
+    // &&& temp offset mock_server.py:292 await self._message_event.write_temperature_offset(
+    {
+        json js;
+        js["id"] = "temperatureOffset";
+        js["ring"] = globals.getTemperatureOffsetsRing();
+        js["intake"] = globals.getTemperatureOffsetsIntake();
+        js["exhaust"] = globals.getTemperatureOffsetsExhaust();
+        _syncWrite(js);
+    }
+
+    // FUTURE: Currently unsure what these messages are supposed to look like.
+    // &&& if self._is_csc:
+    // &&&     await self._message_event.write_detailed_state(DetailedState.PublishOnly)
+    // &&&     await asyncio.sleep(0.01)
+    // &&&     await self._message_event.write_detailed_state(DetailedState.Available)
+
+    // &&& summary_state = salobj.State.OFFLINE if self._is_csc else salobj.State.STANDBY
+    // &&& await self._message_event.write_summary_state(summary_state)
+    {
+        json js;
+        js["id"] = "summaryState";
+        js["summaryState"] = globals.getSummaryState();
+        _syncWrite(js);
+    }
+
+    // &&& # Send the digital input and output
+    // &&& digital_input = self.model.get_digital_input()
+    // &&& await self._message_event.write_digital_input(digital_input)
+    {
+        json js;
+        js["id"] = "digitalInput";
+        js["value"] = globals.getDigitalInput();
+        _syncWrite(js);
+    }
+
+
+    // &&& digital_output = self.model.get_digital_output()
+    // &&& await self._message_event.write_digital_output(digital_output)
+    {
+        json js;
+        js["id"] = "digitalOutput";
+        js["value"] = globals.getDigitalOutput();
+        _syncWrite(js);
+    }
+
+    // &&& await self._message_event.write_config()
+    // TODO: It looks like all of these values should come out of the configuration PLACEHOLDER DM-&&&
+    //       Also, can the gui, and future systems be capable of handling a dump of the entire config in the json msg? Probably useful.
+    // {'id': 'config',
+    // 'configuration': 'Configurable_File_Description_20180831T092556_surrogate_handling.csv',
+    // 'version': '20180831T092556',
+    // 'controlParameters': 'CtrlParameterFiles_2018-07-19_104314_surg',
+    // 'lutParameters': 'FinalHandlingLUTs',
+    // 'powerWarningMotor': 5.0,
+    // 'powerFaultMotor': 10.0,
+    // 'powerThresholdMotor': 20.0,
+    // 'powerWarningComm': 5.0,
+    // 'powerFaultComm': 10.0,
+    // 'powerThresholdComm': 10.0,
+    // 'inPositionAxial': 0.158,
+    // 'inPositionTangent': 1.1,
+    // 'inPositionSample': 1.0,
+    // 'timeoutSal': 15.0,
+    // 'timeoutCrio': 1.0,
+    // 'timeoutIlc': 3,
+    // 'inclinometerDelta': 2.0,
+    // 'inclinometerDiffEnabled': True,
+    // 'cellTemperatureDelta': 2.0}
+    {
+        json js;
+        js["id"] = "config";
+        js["configuration"] = "Configurable_File_Description_20180831T092556_surrogate_handling.csv";
+        js["version"] = "20180831T092556";
+        js["controlParameters"] = "CtrlParameterFiles_2018-07-19_104314_surg";
+        js["lutParameters"] = "FinalHandlingLUTs";
+        js["powerWarningMotor"] = 5.0;
+        js["powerFaultMotor"] = 10.0;
+        js["powerThresholdMotor"] = 20.0;
+        js["powerWarningComm"] = 5.0;
+        js["powerFaultComm"] = 10.0;
+        js["powerThresholdComm"] = 10.0;
+        js["inPositionAxial"] = 0.158;
+        js["inPositionTangent"] = 1.1;
+        js["inPositionSample"] = 1.0;
+        js["timeoutSal"] = 15.0;
+        js["timeoutCrio"] = 1.0;
+        js["timeoutIlc"] = 3;
+        js["inclinometerDelta"] = 2.0;
+        js["inclinometerDiffEnabled"] = true;
+        js["cellTemperatureDelta"] = 2.0;
+        _syncWrite(js);
+    }
+
+    // &&& await self._message_event.write_closed_loop_control_mode(
+    // &&&     ClosedLoopControlMode.Idle
+    // &&& )
+    {
+        json js;
+        js["id"] = "closedLoopControlMode";
+        js["mode"] = globals.getClosedLoopControlMode();
+        _syncWrite(js);
+    }
+
+    // &&& await self._message_event.write_enabled_faults_mask(
+    // &&&     self.model.error_handler.enabled_faults_mask
+    // &&& )
+    {
+        json js;
+        js["id"] = "enabledFaultsMask";
+        js["mode"] = globals.getEnabledFaultMask();
+        _syncWrite(js);
+    }
+
+    // &&& await self._message_event.write_configuration_files()
+    // PLACEHOLDER
+    {
+        json js;
+        js["id"] = "configurationFiles";
+        js["files"] = {"Configurable_File_Description_PLACEHOLDER_M2_optical.csv",
+                       "Configurable_File_Description_PLACEHOLDER_M2_handling.csv",
+                       "Configurable_File_Description_PLACEHOLDER_surrogate_optical.csv",
+                       "Configurable_File_Description_PLACEHOLDER_surrogate_handling.csv"};
+        _syncWrite(js);
+    }
+}
 
 void ComConnection::_receiveCommand() {
     LDEBUG("ComConnection::_receiveCommand");
@@ -155,6 +353,9 @@ void ComConnection::_responseSent(boost::system::error_code const& ec, size_t xf
 void ComConnection::shutdown() {
     if (_shutdown.exchange(true) == true) {
         return;
+    }
+    if (_connectionActive.exchange(false)) {
+        Globals::get().setTcpIpConnected(false);
     }
     // Tell the server to stop tracking this connection
     auto serv = _server.lock();

--- a/src/LSST/system/ComConnection.h
+++ b/src/LSST/system/ComConnection.h
@@ -91,11 +91,17 @@ public:
     /// @return the final string, used for unit testing only.
     static std::string makeTestFinal(std::string const& msg);
 
+    /// &&& doc
+    void setDoSendWelcomeMsg(bool doSend) { _doSendWelcomeMsg = doSend; }
+
 protected:
     /// @see ComConnection::create()
     ComConnection(IoContextPtr const& ioContext, uint64_t connId, std::shared_ptr<ComServer> const& server);
 
 private:
+    /// Send a message with some basic information about the server.
+    void _sendWelcomeMsg();
+
     /// Receive a command from a client.
     void _receiveCommand();
 
@@ -125,6 +131,9 @@ private:
     /// @param xfer The number of bytes sent to a client in a response.
     void _asyncWriteSent(boost::system::error_code const& ec, size_t xfer);
 
+    /// Do a synchronous write using the asio socket and sending `msg`.
+    void _syncWrite(std::string const& msg);
+
     /// A socket for communication with clients
     boost::asio::ip::tcp::socket _socket;
     IoContextPtr _ioContext;
@@ -139,7 +148,11 @@ private:
     boost::asio::streambuf _streamBuf;
     std::string _buffer;
 
-    std::atomic<bool> _shutdown{false};
+    std::atomic<bool> _shutdown{false}; ///< Set to true to stop loops and shutdown.
+    std::atomic<bool> _connectionActive{false}; ///< True when there is an active connection.
+
+    /// If true, send the welcome message when the connection is established.
+    std::atomic<bool> _doSendWelcomeMsg{true};
 };
 
 }  // namespace system

--- a/src/LSST/system/ComConnection.h
+++ b/src/LSST/system/ComConnection.h
@@ -91,7 +91,8 @@ public:
     /// @return the final string, used for unit testing only.
     static std::string makeTestFinal(std::string const& msg);
 
-    /// &&& doc
+    /// New connections will receive the `_sendWelcomeMsg()` when `doSend` is set
+    /// to true. This is only expected to be used for unit tests.
     void setDoSendWelcomeMsg(bool doSend) { _doSendWelcomeMsg = doSend; }
 
 protected:

--- a/src/LSST/system/ComControl.cpp
+++ b/src/LSST/system/ComControl.cpp
@@ -33,6 +33,7 @@
 // Third party headers
 
 // Project headers
+#include "control/NetCommandDefs.h"
 #include "util/Log.h"
 
 using namespace std;
@@ -51,6 +52,7 @@ void ComControl::setupNormalFactory(control::NetCommandFactory::Ptr const& cmdFa
     cmdFactory->addNetCommand(control::NCmdAck::createFactoryVersion());
     cmdFactory->addNetCommand(control::NCmdNoAck::createFactoryVersion());
     cmdFactory->addNetCommand(control::NCmdEcho::createFactoryVersion());
+    cmdFactory->addNetCommand(control::NCmdSwitchCommandSource::createFactoryVersion());
 }
 
 std::tuple<std::string, util::Command::Ptr> ComControl::interpretCommand(std::string const& commandStr) {

--- a/src/LSST/system/ComControlServer.cpp
+++ b/src/LSST/system/ComControlServer.cpp
@@ -47,6 +47,8 @@ ComControlServer::Ptr ComControlServer::create(IoContextPtr const& ioContext, in
 ComConnection::Ptr ComControlServer::newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                                       std::shared_ptr<ComServer> const& server) {
     ComConnection::Ptr ptr = ComControl::create(ioContext, connId, server, _cmdFactory);
+    ptr->setDoSendWelcomeMsg(_doSendWelcomeMsgServ);
+
     return ptr;
 }
 

--- a/src/LSST/system/ComControlServer.cpp
+++ b/src/LSST/system/ComControlServer.cpp
@@ -47,8 +47,7 @@ ComControlServer::Ptr ComControlServer::create(IoContextPtr const& ioContext, in
 ComConnection::Ptr ComControlServer::newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                                       std::shared_ptr<ComServer> const& server) {
     ComConnection::Ptr ptr = ComControl::create(ioContext, connId, server, _cmdFactory);
-    ptr->setDoSendWelcomeMsg(_doSendWelcomeMsgServ);
-
+    ptr->setDoSendWelcomeMsg(getDoSendWelcomeMsgServ());
     return ptr;
 }
 

--- a/src/LSST/system/ComControlServer.h
+++ b/src/LSST/system/ComControlServer.h
@@ -52,6 +52,8 @@ public:
     ComConnection::Ptr newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                         std::shared_ptr<ComServer> const& server) override;
 
+    std::atomic<bool> _doSendWelcomeMsgServ{true}; ///< &&& doc &&& make private.
+
 protected:
     /// Protected constructor to force use of create().
     ComControlServer(IoContextPtr const& ioContext, int port,
@@ -61,6 +63,7 @@ protected:
 private:
     /// NetCommandFactory to decipher messages and provide NetCommands.
     control::NetCommandFactory::Ptr _cmdFactory;
+
 };
 
 }  // namespace system

--- a/src/LSST/system/ComControlServer.h
+++ b/src/LSST/system/ComControlServer.h
@@ -52,8 +52,6 @@ public:
     ComConnection::Ptr newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                         std::shared_ptr<ComServer> const& server) override;
 
-    std::atomic<bool> _doSendWelcomeMsgServ{true}; ///< &&& doc &&& make private.
-
 protected:
     /// Protected constructor to force use of create().
     ComControlServer(IoContextPtr const& ioContext, int port,

--- a/src/LSST/system/ComServer.cpp
+++ b/src/LSST/system/ComServer.cpp
@@ -173,6 +173,7 @@ string ComServer::prettyState(State state) {
 ComConnection::Ptr ComServer::newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                                std::shared_ptr<ComServer> const& server) {
     ComConnection::Ptr ptr = ComConnection::create(ioContext, connId, server);
+    ptr->setDoSendWelcomeMsg(_doSendWelcomeMsgServ);
     return ptr;
 }
 

--- a/src/LSST/system/ComServer.h
+++ b/src/LSST/system/ComServer.h
@@ -70,17 +70,26 @@ public:
     /// Remove 'connId' from the set of ComConnections.
     void eraseConnection(uint64_t connId);
 
-    /// @return the number of active ComConnections.
+    /// Return the number of active ComConnections.
     int connectionCount() const;
 
     State getState() const { return _state; }
 
-    /// @return a new ComConnection object.
+    /// Return a new ComConnection object.
     virtual ComConnection::Ptr newComConnection(IoContextPtr const& ioContext, uint64_t connId,
                                                 std::shared_ptr<ComServer> const& server);
 
-    /// @return Human readable string for State
+    /// Return Human readable string for State
     static std::string prettyState(State state);
+
+    /// Return the value of `_doSendWelcomeMsgServ`, which causes the welcome
+    /// message to be sent on new connections.
+    bool getDoSendWelcomeMsgServ() { return _doSendWelcomeMsgServ; }
+
+    /// Set the value of `_doSendWelcomeMsgServ`, where true means the welcome message will
+    /// be sent, this should be called before the server thread is started.
+    /// Setting `doSend` to false is only meant for unit tests.
+    void setDoSendWelcomeMsgServ(bool doSend) { _doSendWelcomeMsgServ = doSend; }
 
 protected:
     /// Protected constructor to force use of create().
@@ -108,6 +117,9 @@ private:
     /// It should take hundreds or thousands of years for it
     /// uint64_t to wrap around.
     uint64_t _connIdSeq{0};
+
+    /// When true, new connections will start by sending `_sendWelcomeMsg()`.
+    std::atomic<bool> _doSendWelcomeMsgServ{true};
 };
 
 }  // namespace system

--- a/src/LSST/system/Globals.cpp
+++ b/src/LSST/system/Globals.cpp
@@ -1,0 +1,91 @@
+/*
+ *  This file is part of LSST M2 support system package.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+// Class header
+#include "system/Globals.h"
+
+// System headers
+
+// Project headers
+#include "system/Config.h"
+#include "util/Log.h"
+
+using namespace std;
+
+namespace LSST {
+namespace m2cellcpp {
+namespace system {
+
+// static Globals members
+unique_ptr<Globals> Globals::_thisPtr;
+mutex Globals::_thisMtx;
+
+
+void Globals::setup() {
+    lock_guard<mutex> lock(_thisMtx);
+    if (_thisPtr) {
+        LERROR("Globals already setup");
+        return;
+    }
+    _thisPtr = std::unique_ptr<Globals>(new Globals());
+}
+
+Globals::Globals() {
+
+}
+
+void Globals::reset() {
+    LCRITICAL("Config reseting Globals!!!");
+    lock_guard<mutex> lock(_thisMtx);
+    _thisPtr.reset();
+}
+
+
+Globals& Globals::get() {
+    if (_thisPtr == nullptr) {
+        throw ConfigException(ERR_LOC, "Globals has not been setup.");
+    }
+    return *_thisPtr;
+}
+
+
+/// Increase the the number of connections when `connecting` is true, decrease when false;
+void Globals::setTcpIpConnected(bool connecting) {
+    lock_guard<mutex> lock(_tcpIpConnectedMtx);
+    if (connecting) {
+        ++_tcpIpConnectedCount;
+    } else {
+        --_tcpIpConnectedCount;
+    }
+}
+
+/// Return true if the number of connections is greater than zero.
+bool Globals::getTcpIpConnected() const {
+    lock_guard<mutex> lock(_tcpIpConnectedMtx);
+    return (_tcpIpConnectedCount > 0);
+}
+
+
+
+
+}  // namespace system
+}  // namespace m2cellcpp
+}  // namespace LSST

--- a/src/LSST/system/Globals.cpp
+++ b/src/LSST/system/Globals.cpp
@@ -76,6 +76,10 @@ void Globals::setTcpIpConnected(bool connecting) {
     } else {
         --_tcpIpConnectedCount;
     }
+    if (_tcpIpConnectedCount <= 0) {
+        // FUTURE: change state to SAFE MODE - power off ILC communication and actuator motor
+        LCRITICAL("PLACEHOLDER - set system to safe mode");
+    }
 }
 
 /// Return true if the number of connections is greater than zero.

--- a/src/LSST/system/Globals.cpp
+++ b/src/LSST/system/Globals.cpp
@@ -39,16 +39,17 @@ unique_ptr<Globals> Globals::_thisPtr;
 mutex Globals::_thisMtx;
 
 
-void Globals::setup() {
+void Globals::setup(Config const& config) {
     lock_guard<mutex> lock(_thisMtx);
     if (_thisPtr) {
         LERROR("Globals already setup");
         return;
     }
-    _thisPtr = std::unique_ptr<Globals>(new Globals());
+    _thisPtr = std::unique_ptr<Globals>(new Globals(config));
 }
 
-Globals::Globals() {
+
+Globals::Globals(Config const& config) {
 
 }
 

--- a/src/LSST/system/Globals.h
+++ b/src/LSST/system/Globals.h
@@ -1,0 +1,149 @@
+/*
+ *  This file is part of LSST M2 support system package.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_M2CELLCPP_SYSTEM_GLOBALS_H
+#define LSST_M2CELLCPP_SYSTEM_GLOBALS_H
+
+// System headers
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+// Project headers
+
+namespace LSST {
+namespace m2cellcpp {
+namespace system {
+
+class Config;
+
+/// This class is used to contain global instances. It is meant to be
+/// setup once using the system::Config. Setting and values in this class
+/// should be threadsafe and there should only be one instance of this class.
+///
+///For unit testing and other simple tests, the class default values may be used.
+/// FUTURE: Many of the values here are likely to be place holders with values
+///         to help it play nicely with the existing GUI. Eventually, all of these
+///         need to work properly or be removed. This may actually be a reasonable
+///         place to keep these values.
+///         Part of the purpose of this class is to keep the "PLACEHOLDERs" in one
+///         location so they aren't lurking in the depths of the code.
+class Globals {
+public:
+    /// Create the global Context object
+    /// &&& doc
+    static void setup();
+
+    /// &&& doc
+    static void setup(Config const& config);
+
+    /// &&& doc
+    static Globals& get();
+
+    Globals(Globals const&) = delete;
+    Globals& operator=(Globals const&) = delete;
+
+    ~Globals() = default;
+
+    /// &&& all of these vectors must change to be thread safe
+    /// Return const vector of the hardpoints.
+    std::vector<int>& getHardPointList() { return _hardPointList; }
+    /// Return list of ring temperature offsets. PLACEHOLDER
+    std::vector<double>& getTemperatureOffsetsRing() { return _temperatureOffsetsRing; }
+    /// Return list of intake temperature offsets. PLACEHOLDER
+    std::vector<double>& getTemperatureOffsetsIntake() { return _temperatureOffsetsIntake; }
+    /// Return list of exhaust temperature offsets. PLACEHOLDER
+    std::vector<double>& getTemperatureOffsetsExhaust() { return _temperatureOffsetsExhaust; }
+
+    /// Increment the the number of connections when `connecting` is true, decrement when false;
+    void setTcpIpConnected(bool connecting);
+
+    /// Return true if the number of connections is greater than zero.
+    bool getTcpIpConnected() const;
+
+    /// Returns true when system is commandable by DDS. PLACEHOLDER
+    bool getCommandableByDds() const { return _commandableByDds; }
+
+    /// Returns the value of interlock. PLACEHOLDER
+    bool getInterlock() const { return _interlock; }
+
+    /// Returns telemetry source identifier.
+    int getTelemetrySource() const { return _telemetrySource; }
+
+    /// Return summary system state. PLACEHOLDER
+    int getSummaryState() const { return _summaryState; }
+
+    /// Return model digital input. PLACEHOLDER
+    uint32_t getDigitalInput() const { return _digitalInput; }
+
+    /// Return model digital output. PLACEHOLDER
+    uint32_t getDigitalOutput() const { return _digitalOutput; }
+
+    /// Return model enabled fault mask. PLACEHOLDER
+    uint64_t getEnabledFaultMask() const { return _enabledFaultMask; }
+
+    /// Return the closed loop control mode identifier. PLACEHOLDER
+    int getClosedLoopControlMode() const { return _closedLoopControlMode; }
+
+    /// Reset the global Ptr to Globals. PLACEHOLDER
+    /// This should only be called at termination or unit testing.
+    void reset();
+
+private:
+    Globals();
+
+    static std::unique_ptr<Globals> _thisPtr; ///< Pointer to the global instance of Globals
+    static std::mutex _thisMtx;               ///< Protects _thisPtr.
+
+    /// List of hard points.
+    /// FUTURE: Is this where this should be set/stored? PLACEHOLDER
+    std::vector<int> _hardPointList{6, 16, 26, 74, 76, 78};
+
+    /// List of ring temperature offsets. PLACEHOLDER
+    std::vector<double> _temperatureOffsetsRing{21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0};
+    /// List of intake temperature offsets. PLACEHOLDER
+    std::vector<double> _temperatureOffsetsIntake{0.0, 0.0};
+    /// List of exhaust temperature offsets. PLACEHOLDER
+    std::vector<double> _temperatureOffsetsExhaust{0.0, 0.0};
+
+
+    int _tcpIpConnectedCount = 0;  ///< Number of active connections   FUTURE: Should this be in ComControlServer?
+    mutable std::mutex _tcpIpConnectedMtx; ///< protects _tcpIpConnectedCount
+
+    std::atomic<bool> _commandableByDds{true}; ///< True when system commandable by DDS. PLACEHOLDER
+    std::atomic<bool> _interlock{true}; ///< Status of the interlock. PLACEHOLDER
+    std::atomic<int>  _telemetrySource{1}; ///< telemetry source identifier. PLACEHOLDER
+    std::atomic<int> _summaryState{5}; ///< Summary system state. PLACEHOLDER from python - salobj.State.OFFLINE=5
+
+    std::atomic<uint32_t> _digitalInput{0x9F00FFFF}; ///< Model digital input PLACEHOLDER from python = 2667642879
+    std::atomic<uint32_t> _digitalOutput{0x1C}; ///< Model digital output PLACEHOLDER from python = 28
+    std::atomic<uint64_t> _enabledFaultMask{0xff800007ffffffff}; ///< Model enabled fault mask. PLACEHOLDER from python = 18410715311050326015
+
+    std::atomic<int> _closedLoopControlMode{1}; ///< Closed loop control mode. PLACEHOLDER from python 1=ClosedLoopControlMode.Idle
+
+};
+
+}  // namespace system
+}  // namespace m2cellcpp
+}  // namespace LSST
+
+#endif  // LSST_M2CELLCPP_SYSTEM_GLOBALS_H

--- a/src/LSST/system/Globals.h
+++ b/src/LSST/system/Globals.h
@@ -85,7 +85,7 @@ public:
         std::lock_guard<std::mutex> lock(_temperatureOffsetsExhaustMtx);
         return _temperatureOffsetsExhaust; }
 
-    /// Increment the the number of connections when `connecting` is true, decrement when false;
+    /// Increment the number of connections when `connecting` is true, decrement when false;
     void setTcpIpConnected(bool connecting);
 
     /// Return true if the number of connections is greater than zero.
@@ -134,11 +134,13 @@ private:
     static std::mutex _thisMtx;               ///< Protects _thisPtr.
 
     /// List of hard points.
+    /// The hardpoint list is the 1-based index {6, 16, 26, 74, 76, 78}
+    /// some calculations are done with the 0-based index {5, 15,25,73, 75, 77}
     /// FUTURE: Is this where this should be set/stored? PLACEHOLDER
     std::vector<int> _hardPointList{6, 16, 26, 74, 76, 78};
     std::mutex _hardPointListMtx; ///< Protects `_hardPointList`
 
-    /// List of ring temperature offsets. PLACEHOLDER
+    /// List of ring temperature offsets in degrees C. PLACEHOLDER
     std::vector<double> _temperatureOffsetsRing{21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0, 21.0};
     std::mutex _temperatureOffsetsRingMtx; ///< Protects `_temperatureOffsetsRing`
 
@@ -165,10 +167,6 @@ private:
     std::atomic<int> _closedLoopControlMode{1}; ///< Closed loop control mode. PLACEHOLDER from python 1=ClosedLoopControlMode.Idle
 
     std::atomic<bool> _commandSourceIsRemote{false}; ///< Command source is remote when true, otherwise false.
-
-
-
-
 
 };
 

--- a/tests/test_Com.cpp
+++ b/tests/test_Com.cpp
@@ -35,6 +35,7 @@
 #include "system/Config.h"
 #include "system/ComClient.h"
 #include "system/ComServer.h"
+#include "system/Globals.h"
 #include "util/Log.h"
 
 using namespace std;
@@ -44,6 +45,7 @@ TEST_CASE("Test Com echo", "[Com]") {
     LSST::m2cellcpp::util::Log::getLog().useEnvironmentLogLvl();
     string cfgPath = Config::getEnvironmentCfgPath("../configs");
     Config::setup(cfgPath + "unitTestCfg.yaml");
+    Globals::setup();
 
     REQUIRE(ComServer::prettyState(ComServer::CREATED) == "CREATED");
     REQUIRE(ComServer::prettyState(ComServer::RUNNING) == "RUNNING");

--- a/tests/test_Com.cpp
+++ b/tests/test_Com.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Test Com echo", "[Com]") {
     LSST::m2cellcpp::util::Log::getLog().useEnvironmentLogLvl();
     string cfgPath = Config::getEnvironmentCfgPath("../configs");
     Config::setup(cfgPath + "unitTestCfg.yaml");
-    Globals::setup();
+    Globals::setup(Config::get());
 
     REQUIRE(ComServer::prettyState(ComServer::CREATED) == "CREATED");
     REQUIRE(ComServer::prettyState(ComServer::RUNNING) == "RUNNING");
@@ -57,9 +57,9 @@ TEST_CASE("Test Com echo", "[Com]") {
     auto serv = ComServer::create(ioContext, port);
     atomic<bool> done{false};
     REQUIRE(serv->getState() == ComServer::CREATED);
-    LDEBUG("server started");
-
-    thread servThrd([&serv, &done]() {
+    serv->setDoSendWelcomeMsgServ(false);
+    LDEBUG("server starting");
+    thread servThrd([serv, &done]() {
         LINFO("server run ", serv->prettyState(serv->getState()));
         serv->run();
         LINFO("server finish");

--- a/tests/test_ComControl.cpp
+++ b/tests/test_ComControl.cpp
@@ -35,8 +35,6 @@ using namespace std;
 using namespace LSST::m2cellcpp::system;
 using namespace LSST::m2cellcpp;
 
-
-
 tuple<nlohmann::json, nlohmann::json> comTest(string const& jStr, ComClient& client, string const& note) {
     client.writeCommand(jStr);
     LDEBUG(note, ":wrote jStr=", jStr);

--- a/tests/test_ComControl.cpp
+++ b/tests/test_ComControl.cpp
@@ -28,13 +28,17 @@
 #include "system/ComControlServer.h"
 #include "system/ComServer.h"
 #include "system/Config.h"
+#include "system/Globals.h"
 #include "util/Log.h"
 
 using namespace std;
 using namespace LSST::m2cellcpp::system;
 using namespace LSST::m2cellcpp;
 
+
+
 tuple<nlohmann::json, nlohmann::json> comTest(string const& jStr, ComClient& client, string const& note) {
+    Globals::setup();
     client.writeCommand(jStr);
     LDEBUG(note, ":wrote jStr=", jStr);
     auto ack = client.readCommand();
@@ -51,12 +55,15 @@ TEST_CASE("Test ComControl", "[ComControl]") {
     string cfgPath = Config::getEnvironmentCfgPath("../configs");
     Config::setup(cfgPath + "unitTestCfg.yaml");
 
+
+
     // Start a ComControlServer
     IoContextPtr ioContext = make_shared<boost::asio::io_context>();
     int port = Config::get().getControlServerPort();
     auto cmdFactory = control::NetCommandFactory::create();
     ComControl::setupNormalFactory(cmdFactory);
     auto serv = ComControlServer::create(ioContext, port, cmdFactory);
+    serv->_doSendWelcomeMsgServ = false;
 
     atomic<bool> done{false};
     REQUIRE(serv->getState() == ComServer::CREATED);

--- a/tests/test_NetCommand.cpp
+++ b/tests/test_NetCommand.cpp
@@ -34,10 +34,10 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     LSST::m2cellcpp::util::Log::getLog().useEnvironmentLogLvl();
     {
         // Test basic functionality of base class
-        string jStr = "{\"id\":\"cmd_ack\",\"seq_id\": 5 }";
+        string jStr = "{\"id\":\"cmd_ack\",\"sequence_id\": 5 }";
         NetCommand::JsonPtr jsn = NetCommand::parse(jStr);
         REQUIRE(jsn->at("id") == "cmd_ack");
-        REQUIRE(jsn->at("seq_id") == 5);
+        REQUIRE(jsn->at("sequence_id") == 5);
         NetCommand::Ptr cmd1 = NCmdAck::create(jsn);
         REQUIRE(cmd1->getName() == "cmd_ack");
         REQUIRE(cmd1->getSeqId() == 5);
@@ -56,7 +56,7 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     LDEBUG(note);
     bool thrown = false;
     try {
-        string jStr = "\"id\":\"cmd_ack\",\"seq_id\": 1 }";
+        string jStr = "\"id\":\"cmd_ack\",\"sequence_id\": 1 }";
         auto jsn = NetCommand::parse(jStr);
     } catch (NetCommandException const& ex) {
         LDEBUG(note, ex.what());
@@ -68,7 +68,7 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     LDEBUG(note);
     try {
         thrown = false;
-        string jStr = "{\"seq_id\": 1 }";
+        string jStr = "{\"sequence_id\": 1 }";
         auto jsn = NetCommand::parse(jStr);
     } catch (NetCommandException const& ex) {
         LDEBUG(note, ex.what());
@@ -76,11 +76,11 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     }
     REQUIRE(thrown);
 
-    note = "seq_id not int ";
+    note = "sequence_id not int ";
     LDEBUG(note);
     try {
         thrown = false;
-        string jStr = "{\"id\":\"cmd_ack\",\"seq_id\":\"hello\" }";
+        string jStr = "{\"id\":\"cmd_ack\",\"sequence_id\":\"hello\" }";
         auto jsn = NetCommand::parse(jStr);
     } catch (NetCommandException const& ex) {
         LDEBUG(note, ex.what());
@@ -102,7 +102,7 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     note = "create test";
     LDEBUG(note);
     {
-        auto js1 = NetCommand::JsonPtr(new nlohmann::json{{"id", "cmd_ack"}, {"seq_id", 7}});
+        auto js1 = NetCommand::JsonPtr(new nlohmann::json{{"id", "cmd_ack"}, {"sequence_id", 7}});
         auto cmd = NCmdAck::create(js1);
         REQUIRE(cmd != nullptr);
     }
@@ -123,7 +123,7 @@ TEST_CASE("Test NetCommand", "[NetCommand]") {
     LDEBUG(note);
     try {
         thrown = false;
-        auto js1 = NetCommand::JsonPtr(new nlohmann::json{{"seq_id", 7}});
+        auto js1 = NetCommand::JsonPtr(new nlohmann::json{{"sequence_id", 7}});
         auto cmd = NCmdAck::create(js1);
     } catch (NetCommandException const& ex) {
         LDEBUG(note, ex.what());
@@ -147,11 +147,11 @@ TEST_CASE("Test NetCommandFactory", "[Factory]") {
         auto ackStr = noAckCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
         REQUIRE(ackJ["id"] == "noack");
-        REQUIRE(ackJ["seq_id"] == 0);
+        REQUIRE(ackJ["sequence_id"] == 0);
         REQUIRE(ackJ["user_info"] == "factory default noack");
     }
 
-    string jStr1 = "{\"id\":\"cmd_ack\",\"seq_id\": 1 }";
+    string jStr1 = "{\"id\":\"cmd_ack\",\"sequence_id\": 1 }";
     {
         string note = "Correct NCmdAck jStr ";
         LDEBUG(note);
@@ -161,31 +161,31 @@ TEST_CASE("Test NetCommandFactory", "[Factory]") {
         REQUIRE(inNCmdAck != nullptr);
         auto ackStr = inNCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
-        REQUIRE(ackJ["seq_id"] == 1);
+        REQUIRE(ackJ["sequence_id"] == 1);
         REQUIRE(ackJ["id"] == "ack");
         REQUIRE(inNCmd->run() == true);
         auto respStr = inNCmd->getRespJsonStr();
         auto respJ = nlohmann::json::parse(respStr);
-        REQUIRE(respJ["seq_id"] == 1);
+        REQUIRE(respJ["sequence_id"] == 1);
         REQUIRE(respJ["id"] == "success");
     }
 
     {
         string note = "Correct NCmdEcho jStr ";
         LDEBUG(note);
-        string jStr = "{\"id\":\"cmd_echo\",\"seq_id\": 2, \"msg\":\"This is an echomsg\" }";
+        string jStr = "{\"id\":\"cmd_echo\",\"sequence_id\": 2, \"msg\":\"This is an echomsg\" }";
         auto inNCmd = factory->getCommandFor(jStr);
         REQUIRE(inNCmd != nullptr);
         auto inNCmdEcho = dynamic_pointer_cast<NCmdEcho>(inNCmd);
         REQUIRE(inNCmdEcho != nullptr);
         auto ackStr = inNCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
-        REQUIRE(ackJ["seq_id"] == 2);
+        REQUIRE(ackJ["sequence_id"] == 2);
         REQUIRE(ackJ["id"] == "ack");
         REQUIRE(inNCmd->run() == true);
         auto respStr = inNCmd->getRespJsonStr();
         auto respJ = nlohmann::json::parse(respStr);
-        REQUIRE(respJ["seq_id"] == 2);
+        REQUIRE(respJ["sequence_id"] == 2);
         REQUIRE(respJ["id"] == "success");
         string respMsg = respJ["msg"];
         REQUIRE(respJ["msg"] == "This is an echomsg");
@@ -194,24 +194,24 @@ TEST_CASE("Test NetCommandFactory", "[Factory]") {
     {
         string note = "Incorrect NCmdAck jStr ";
         LDEBUG(note);
-        string jStr = "{\"id\":\"cmd_ak\",\"seq_id\": 3 }";
+        string jStr = "{\"id\":\"cmd_ak\",\"sequence_id\": 3 }";
         auto inNCmd = factory->getCommandFor(jStr);
         REQUIRE(inNCmd != nullptr);
         auto inNCmdNoAck = dynamic_pointer_cast<NCmdNoAck>(inNCmd);
         REQUIRE(inNCmdNoAck != nullptr);
         auto ackStr = inNCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
-        REQUIRE(ackJ["seq_id"] == 3);
+        REQUIRE(ackJ["sequence_id"] == 3);
         REQUIRE(ackJ["id"] == "noack");
         REQUIRE(inNCmd->run() == false);
         auto respStr = inNCmd->getRespJsonStr();
         auto respJ = nlohmann::json::parse(respStr);
-        REQUIRE(respJ["seq_id"] == 3);
+        REQUIRE(respJ["sequence_id"] == 3);
         REQUIRE(respJ["id"] == "fail");
     }
 
     {
-        string note = "Incorrect seq_id NCmdAck jStr ";
+        string note = "Incorrect sequence_id NCmdAck jStr ";
         LDEBUG(note);
         auto inNCmd = factory->getCommandFor(jStr1);
         REQUIRE(inNCmd != nullptr);
@@ -219,31 +219,31 @@ TEST_CASE("Test NetCommandFactory", "[Factory]") {
         REQUIRE(inNCmdNoAck != nullptr);
         auto ackStr = inNCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
-        REQUIRE(ackJ["seq_id"] == 1);
+        REQUIRE(ackJ["sequence_id"] == 1);
         REQUIRE(ackJ["id"] == "noack");
         REQUIRE(inNCmd->run() == false);
         auto respStr = inNCmd->getRespJsonStr();
         auto respJ = nlohmann::json::parse(respStr);
-        REQUIRE(respJ["seq_id"] == 1);
+        REQUIRE(respJ["sequence_id"] == 1);
         REQUIRE(respJ["id"] == "fail");
     }
 
     {
         string note = "Echo missing message jStr ";
         LDEBUG(note);
-        string jStr = "{\"id\":\"cmd_echo\",\"seq_id\": 4, \"msgg\":\"This is an echomsg\" }";
+        string jStr = "{\"id\":\"cmd_echo\",\"sequence_id\": 4, \"msgg\":\"This is an echomsg\" }";
         auto inNCmd = factory->getCommandFor(jStr);
         REQUIRE(inNCmd != nullptr);
         auto inNCmdNoAck = dynamic_pointer_cast<NCmdNoAck>(inNCmd);
         REQUIRE(inNCmdNoAck != nullptr);
         auto ackStr = inNCmd->getAckJsonStr();
         auto ackJ = nlohmann::json::parse(ackStr);
-        REQUIRE(ackJ["seq_id"] == 4);
+        REQUIRE(ackJ["sequence_id"] == 4);
         REQUIRE(ackJ["id"] == "noack");
         REQUIRE(inNCmd->run() == false);
         auto respStr = inNCmd->getRespJsonStr();
         auto respJ = nlohmann::json::parse(respStr);
-        REQUIRE(respJ["seq_id"] == 4);
+        REQUIRE(respJ["sequence_id"] == 4);
         REQUIRE(respJ["id"] == "fail");
         LDEBUG("ackJson=", ackJ.dump());
         LDEBUG("respJson=", respJ.dump());


### PR DESCRIPTION
There are several "PLACEHOLDER" entries that eventually need to be replaced by real values. FInding where and what they do in the LabView code is no small task, but eventually they will all need to be replaced with code that really does something, and it is important that they are not forgotten.

Relatively simple unhandled exceptions tend to cause the unit testing framework (catch2) to have segmentation faults in it's threads. These masked simple problems, especially when using gdb. 

I was hoping to be a bit further along in the functionality behind this ticket, but a basic command can be completed successfully.