### PR TITLE
Tickets/dm 41795

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -18,7 +18,7 @@ INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 # The optimizer is doing somthing at -O3 that causes segfaults when -g is not used.
 ifdef DEBUG
-  c_opts := -g -O2
+  c_opts := -g
 else
   c_opts := -O2
 endif

--- a/configs/unitTestCfg.yaml
+++ b/configs/unitTestCfg.yaml
@@ -10,7 +10,7 @@ Log:
 ControlServer:
   host: "127.0.0.1"
   port: 12678
-  threads: 1
+  threads: 3
 
 # Acceptable values for the telemetry server.
 TelemetryServer:

--- a/doc/comClassUML.txt
+++ b/doc/comClassUML.txt
@@ -31,6 +31,8 @@ NetCommand <|-- NCmdAck
 NetCommand <|-- NCmdNoAck
 NetCommand <|-- NCmdEcho
 NetCommand <|-- NCmdSwitchCommandSource
+NetCommand <|-- NCmdPower
+NetCommand <|-- NCmdShutdown
 
 NetCommandException <.. NetCommandFactory : throws
 

--- a/doc/powerSystemUML.txt
+++ b/doc/powerSystemUML.txt
@@ -11,6 +11,9 @@ class PowerSubsystemConfig
 class BreakerFeedGroup
 class Feed
 
+class Context
+class Model
+
 
 class InputPortBits
 class OutputPortBits
@@ -40,10 +43,15 @@ PowerSystem .. FaultMgr : faults
 PowerSubsystem .. FaultMgr : faults
 ComControl .. FaultMgr : faults
 
+Context *-- Model
+
 
 FpgaIo o.. SysInfo
 FpgaIo o.. SimCore
 PowerSystem o.. SysInfo
+
+PowerSystem o.. Context : state changes
+Model *-- PowerSystem
 
 SysInfo *-- InputPortBits
 SysInfo *-- OutputPortBits

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+0.3.7
+
+ - Added cmd_power and integration test.
+
 0.3.6
 
  - Reworked the Model state machine. 

--- a/serverMain/main.cpp
+++ b/serverMain/main.cpp
@@ -19,14 +19,12 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
-
 #include "control/ControlMain.h"
 #include "system/Config.h"
 #include "util/Log.h"
 
 using namespace std;
 using namespace LSST::m2cellcpp;
-
 
 int main(int argc, const char* argv[]) {
     // Store log messages and send to cout until the logfile is setup.

--- a/serverMain/main.cpp
+++ b/serverMain/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[]) {
     /// Start the main thread
     control::ControlMain::setup();
     control::ControlMain::Ptr ctMain = control::ControlMain::getPtr();
-    ctMain->run(argc, argv);
+    ctMain->run();
     LINFO("ctrlMain started");
 
     ctMain->join();

--- a/serverMain/main.cpp
+++ b/serverMain/main.cpp
@@ -19,40 +19,24 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
-#include "control/Context.h"
-#include "control/FpgaIo.h"
-#include "control/MotionEngine.h"
-#include "faultmgr/FaultMgr.h"
-#include "simulator/SimCore.h"
-#include "system/ComControl.h"
-#include "system/ComControlServer.h"
+
+#include "control/ControlMain.h"
 #include "system/Config.h"
-#include "system/Globals.h"
-#include "system/TelemetryCom.h"
-#include "system/TelemetryMap.h"
 #include "util/Log.h"
 
 using namespace std;
 using namespace LSST::m2cellcpp;
 
-void signalHandler(int sig) {
-    if (sig == SIGPIPE) {
-        LWARN("Ignoring SIGPIPE sig=", sig);
-        return;
-    }
-    LCRITICAL("Unhandled signal caught sig=", sig);
-    exit(sig);
-}
 
-int main(int argc, char* argv[]) {
+int main(int argc, const char* argv[]) {
     // Store log messages and send to cout until the logfile is setup.
     // If environment LOGLVL is undefined, defaults to `trace`.
     LSST::m2cellcpp::util::Log::getLog().useEnvironmentLogLvl();
     util::Log& log = util::Log::getLog();
     log.setOutputDest(util::Log::MIRRORED);
-    LINFO("starting main");
 
     // Read the configuration
+    LINFO("Reading Config");
     string cfgPath = system::Config::getEnvironmentCfgPath("./configs");
     system::Config::setup(cfgPath + "m2cellCfg.yaml");
     system::Config& sysCfg = system::Config::get();
@@ -70,106 +54,16 @@ int main(int argc, char* argv[]) {
     log.setOutputDest(util::Log::SPEEDLOG);
     // FUTURE: DM-39974 add command line argument to turn `Log::_alwaysFlush` off.
     log.setAlwaysFlush(true);  // spdlog is highly prone to waiting a long time before writing to disk.
-    LINFO("Main - logging ready");
+    LINFO("Logging ready");
 
-    // Setup global items.
-    system::Globals::setup(sysCfg);
+    /// Start the main thread
+    control::ControlMain::setup();
+    control::ControlMain::Ptr ctMain = control::ControlMain::getPtr();
+    ctMain->run(argc, argv);
+    LINFO("ctrlMain started");
 
-    // Setup a simple signal handler to handle when clients closing connection results in SIGPIPE.
-    signal(SIGPIPE, signalHandler);
-
-    // Create the control system
-    LSST::m2cellcpp::simulator::SimCore::Ptr simCore(new LSST::m2cellcpp::simulator::SimCore());
-    simCore->start();
-    faultmgr::FaultMgr::setup();
-    control::FpgaIo::setup(simCore);
-    control::MotionEngine::setup();
-    control::Context::setup();
-
-    // Register the PowerSystem with FpgaIo so that it gets updates.
-    auto powerSys = control::Context::get()->model.getPowerSystem();
-    control::FpgaIo::get().registerPowerSys(powerSys);
-
-    // Setup the control system
-    auto context = control::Context::get();
-    context->model.ctrlSetup();
-
-    // At this point, MotionCtrl and FpgaCtrl should be configured. Start the control loops
-    context->model.ctrlStart();
-
-    // At this point, the LabView code seems to want to put the system into
-    // ReadyIdle. We're NOT doing that. The system is going into StandbyState
-    // until it gets an explicit command to do something else.
-
-    // Start the telemetry server
-    // FUTURE: Telemetry for the GUI requires the ComControlServer->ComConnection::welcomeMsg to
-    //         work properly. Those elements should be in the telemetry so there's no need for a
-    //         ComControlServer connection for Telemetry. This has to wait until the existing
-    //         controller is no longer used.
-    LINFO("Starting Telemetry Server");
-    // FUTURE: get the correct entries into `system::Config`.
-    int const telemPort = 50001;
-    auto servTelemetryMap = system::TelemetryMap::Ptr(new system::TelemetryMap());
-    auto telemetryServ = system::TelemetryCom::create(servTelemetryMap, telemPort);
-
-    telemetryServ->startServer();
-    if (!telemetryServ->waitForServerRunning(5)) {
-        LCRITICAL("Telemetry server failed to start.");
-        exit(-1);  // change to powerdown and exit
-    }
-
-    // Wait for MotionCtrl to be ready
-    context->model.waitForCtrlReady();
-
-    // Start a ComControlServer
-    LDEBUG("ComControlServer starting...");
-    system::IoContextPtr ioContext = make_shared<boost::asio::io_context>();
-    int port = system::Config::get().getControlServerPort();
-    auto cmdFactory = control::NetCommandFactory::create();
-    system::ComControl::setupNormalFactory(cmdFactory);
-    auto serv = system::ComControlServer::create(ioContext, port, cmdFactory, true);
-    LINFO("ComControlServer created port=", port);
-
-    atomic<bool> comServerDone{false};
-    auto comServState = serv->getState();
-    LDEBUG("ComControlServer comServState=", serv->prettyState(comServState));
-
-    thread comControlServThrd([&serv, &comServerDone, &log]() {
-        LINFO("server run ", serv->prettyState(serv->getState()));
-        log.flush();
-        serv->run();
-        LINFO("server finish");
-        comServerDone = true;
-    });
-
-    // FUTURE: Add a NetCommand to terminate the service which will
-    //   - send shutdown  to ComServer.
-    //   - send shutdown  to TelemetryServer
-
-    // Wait as long as the server is running. At some point,
-    // something should call comServ->shutdown().
-    LDEBUG("ComControlServer waiting for server shutdown");
-    while (serv->getState() != system::ComServer::STOPPED) {
-        sleep(1);
-    }
-
-    // This will terminate all TCP/IP communication.
-    ioContext->stop();
-    for (int j = 0; !comServerDone && j < 10; ++j) {
-        sleep(1);
-        bool d = comServerDone;
-        LINFO("server wait ", d);
-    }
-    LINFO("server stopped");
-
-    context->model.ctrlStop();
-    LINFO("stopping model");
-
-    comControlServThrd.join();
-    LINFO("server joined");
-
-    context->model.ctrlJoin();
-    LINFO("Model threads joined");
+    ctMain->join();
+    LINFO("ctrlMain joined");
 
     return 0;
 }

--- a/src/LSST/control/CellCtrlComm.h
+++ b/src/LSST/control/CellCtrlComm.h
@@ -34,7 +34,7 @@ namespace control {
 /// This class represents Controller->startupCellCommunications and CellCommunications.vi.
 /// It is currently just a PLACEHOLDER for CellCommunication.vi, which is the major control loop
 /// for ILC control.
-/// CellCommunication.vi responsibilities.
+/// CellCommunications.vi responsibilities.
 ///   ILC control
 ///   Process the raw sensor telemetry to be physically meaningful values
 ///   feedforward and feedback control loops

--- a/src/LSST/control/Context.cpp
+++ b/src/LSST/control/Context.cpp
@@ -25,6 +25,7 @@
 // System headers
 
 // Project headers
+#include "control/PowerSystem.h"
 #include "util/Log.h"
 
 using namespace std;
@@ -38,12 +39,15 @@ Context::Ptr Context::_thisPtr;
 std::mutex Context::_thisMtx;
 
 void Context::setup() {
-    lock_guard<mutex> lock(_thisMtx);
-    if (_thisPtr) {
-        LERROR("Config already setup");
-        return;
+    {
+        lock_guard<mutex> lock(_thisMtx);
+        if (_thisPtr) {
+            LERROR("Config already setup");
+            return;
+        }
+        _thisPtr = Ptr(new Context());
     }
-    _thisPtr = Ptr(new Context());
+    _thisPtr->model.getPowerSystem()->setContext(_thisPtr);
 }
 
 Context::Ptr Context::get() {

--- a/src/LSST/control/Context.cpp
+++ b/src/LSST/control/Context.cpp
@@ -42,7 +42,7 @@ void Context::setup() {
     {
         lock_guard<mutex> lock(_thisMtx);
         if (_thisPtr) {
-            LERROR("Config already setup");
+            LERROR("Context already setup");
             return;
         }
         _thisPtr = Ptr(new Context());

--- a/src/LSST/control/ControlMain.cpp
+++ b/src/LSST/control/ControlMain.cpp
@@ -209,6 +209,7 @@ void ControlMain::stop() {
     // Stop the ComServer, which should cause `run(..)` to end.
     LINFO("ControlMain::stop() shutting down ComControlServer.");
     _comServer->shutdown();
+    _comServer->destroy();
 }
 
 void ControlMain::join() {

--- a/src/LSST/control/ControlMain.cpp
+++ b/src/LSST/control/ControlMain.cpp
@@ -71,10 +71,9 @@ ControlMain::ControlMain() {}
 ControlMain::~ControlMain() {}
 
 void ControlMain::run(int argc, const char* argv[]) {
-        thread t(&ControlMain::_cMain, this, argc, argv);
-        _mainThrd = move(t);
+    thread t(&ControlMain::_cMain, this, argc, argv);
+    _mainThrd = move(t);
 }
-
 
 void signalHandler(int sig) {
     if (sig == SIGPIPE) {
@@ -171,11 +170,11 @@ void ControlMain::_cMain(int argc, const char* argv[]) {
             sleep(1);
         }
         if (j >= maxSeconds) {
-            throw util::Bug(ERR_LOC, "ControlMain server did not start within " + to_string(maxSeconds) + " seconds");
+            throw util::Bug(ERR_LOC,
+                            "ControlMain server did not start within " + to_string(maxSeconds) + " seconds");
         }
         _running = true;
     }
-
 
     // Wait as long as the server is running. At some point,
     // something should call comServ->shutdown(). When the

--- a/src/LSST/control/ControlMain.cpp
+++ b/src/LSST/control/ControlMain.cpp
@@ -27,8 +27,17 @@
 #include <ctime>
 
 // project headers
+#include "control/Context.h"
+#include "control/FpgaIo.h"
+#include "control/MotionEngine.h"
 #include "faultmgr/FaultMgr.h"
+#include "simulator/SimCore.h"
+#include "system/ComControl.h"
+#include "system/ComControlServer.h"
 #include "system/Config.h"
+#include "system/Globals.h"
+#include "system/TelemetryCom.h"
+#include "system/TelemetryMap.h"
 #include "util/Bug.h"
 #include "util/Log.h"
 
@@ -57,16 +66,161 @@ ControlMain::Ptr ControlMain::getPtr() {
     return _thisPtr;
 }
 
-ControlMain& ControlMain::get() {
-    if (_thisPtr == nullptr) {
-        throw system::ConfigException(ERR_LOC, "ControlMain has not been setup.");
-    }
-    return *_thisPtr;
-}
-
 ControlMain::ControlMain() {}
 
 ControlMain::~ControlMain() {}
+
+void ControlMain::run(int argc, const char* argv[]) {
+        thread t(&ControlMain::_cMain, this, argc, argv);
+        _mainThrd = move(t);
+}
+
+
+void signalHandler(int sig) {
+    if (sig == SIGPIPE) {
+        LWARN("Ignoring SIGPIPE sig=", sig);
+        return;
+    }
+    LCRITICAL("Unhandled signal caught sig=", sig);
+    exit(sig);
+}
+
+void ControlMain::_cMain(int argc, const char* argv[]) {
+    LINFO("starting main");
+    util::Log& log = util::Log::getLog();
+
+    // Get the configuration
+    system::Config& sysCfg = system::Config::get();
+
+    // Setup global items.
+    system::Globals::setup(sysCfg);
+
+    // Setup a simple signal handler to handle when clients closing connection results in SIGPIPE.
+    signal(SIGPIPE, signalHandler);
+
+    // Create the control system
+    _simCore.reset(new LSST::m2cellcpp::simulator::SimCore());
+    _simCore->start();
+    faultmgr::FaultMgr::setup();
+    control::FpgaIo::setup(_simCore);
+    control::MotionEngine::setup();
+    control::Context::setup();
+
+    // Register the PowerSystem with FpgaIo so that it gets updates.
+    auto powerSys = control::Context::get()->model.getPowerSystem();
+    control::FpgaIo::get().registerPowerSys(powerSys);
+
+    // Setup the control system
+    auto context = control::Context::get();
+    context->model.ctrlSetup();
+
+    // At this point, MotionCtrl and FpgaCtrl should be configured. Start the control loops
+    context->model.ctrlStart();
+
+    // At this point, the LabView code seems to want to put the system into
+    // ReadyIdle. We're NOT doing that. The system is going into StandbyState
+    // until it gets an explicit command to do something else.
+
+    // Start the telemetry server
+    // FUTURE: Telemetry for the GUI requires the ComControlServer->ComConnection::welcomeMsg to
+    //         work properly. Those elements should be in the telemetry so there's no need for a
+    //         ComControlServer connection for Telemetry. This has to wait until the existing
+    //         controller is no longer used.
+    LINFO("Starting Telemetry Server");
+    // FUTURE: get the correct entries into `system::Config`.
+    int const telemPort = 50001;
+    auto servTelemetryMap = system::TelemetryMap::Ptr(new system::TelemetryMap());
+    auto telemetryServ = system::TelemetryCom::create(servTelemetryMap, telemPort);
+
+    telemetryServ->startServer();
+    if (!telemetryServ->waitForServerRunning(5)) {
+        LCRITICAL("Telemetry server failed to start.");
+        exit(-1);  // change to powerdown and exit
+    }
+
+    // Wait for MotionCtrl to be ready
+    context->model.waitForCtrlReady();
+
+    // Start a ComControlServer
+    LDEBUG("ComControlServer starting...");
+    system::IoContextPtr ioContext = make_shared<boost::asio::io_context>();
+    int port = system::Config::get().getControlServerPort();
+    auto cmdFactory = control::NetCommandFactory::create();
+    system::ComControl::setupNormalFactory(cmdFactory);
+    _comServer = system::ComControlServer::create(ioContext, port, cmdFactory, true);
+    LINFO("ComControlServer created port=", port);
+
+    atomic<bool> comServerDone{false};
+    auto comServState = _comServer->getState();
+    LDEBUG("ComControlServer comServState=", _comServer->prettyState(comServState));
+
+    auto cServ = _comServer;
+    thread comControlServThrd([&cServ, &comServerDone, &log]() {
+        LINFO("server run ", cServ->prettyState(cServ->getState()));
+        log.flush();
+        cServ->run();
+        LINFO("server finish");
+        comServerDone = true;
+    });
+
+    // wait for the server to be running
+    {
+        int j = 0;
+        int const maxSeconds = 30;
+        for (; (cServ->getState() != LSST::m2cellcpp::system::ComServer::RUNNING) && j < maxSeconds; ++j) {
+            sleep(1);
+        }
+        if (j >= maxSeconds) {
+            throw util::Bug(ERR_LOC, "ControlMain server did not start within " + to_string(maxSeconds) + " seconds");
+        }
+        _running = true;
+    }
+
+
+    // Wait as long as the server is running. At some point,
+    // something should call comServ->shutdown(). When the
+    // server is shutdown, the rest of the program will try
+    // to shutdown in an orderly manner.
+    LINFO("ComControlServer is running, waiting for server shutdown");
+    while (_comServer->getState() != system::ComServer::STOPPED) {
+        sleep(1);
+    }
+    LINFO("ComControlServer has been shutdown");
+
+    // This will terminate all TCP/IP communication.
+    LINFO("ioContext->stop();");
+    ioContext->stop();
+    for (int j = 0; !comServerDone && j < 10; ++j) {
+        sleep(1);
+        bool d = comServerDone;
+        LINFO("server wait ", d);
+    }
+    LINFO("server stopped");
+    context->model.ctrlStop();
+
+    LINFO("stopping model");
+    context->model.ctrlJoin();
+
+    LINFO("joining server");
+    comControlServThrd.join();
+    LINFO("server joined");
+}
+
+void ControlMain::stop() {
+    // Stop the ComServer, which should cause `run(..)` to end.
+    LINFO("ControlMain::stop() shutting down ComControlServer.");
+    _comServer->shutdown();
+}
+
+void ControlMain::join() {
+    LINFO("ControlMain joining the main thread.");
+    if (_mainThrd.joinable()) {
+        _mainThrd.join();
+        LINFO("ControlMain main thread joined.");
+    } else {
+        LINFO("ControlMain main thread not joinable.");
+    }
+}
 
 }  // namespace control
 }  // namespace m2cellcpp

--- a/src/LSST/control/ControlMain.h
+++ b/src/LSST/control/ControlMain.h
@@ -31,6 +31,15 @@
 
 namespace LSST {
 namespace m2cellcpp {
+
+namespace simulator {
+class SimCore;
+}
+
+namespace system {
+class ComControlServer;
+}
+
 namespace control {
 
 /// PLACEHOLDER This class will contain a thread running the main instance of the program.
@@ -47,13 +56,30 @@ public:
     /// Verify threads are stopped and joined.
     ~ControlMain();
 
-    /// Return a reference to the global ControlMain instance.
-    /// @throws `ConfigException` if `setup` has not already been called.
-    static ControlMain& get();
-
     /// Return a shared pointer to the global ControlMain instance.
     /// @throws `ConfigException` if `setup` has not already been called.
     static Ptr getPtr();
+
+    /// &&& doc
+    void run(int argc, const char* argv[]);
+
+    /// Returns true once the server is running.
+    bool getRunning() { return _running; }
+
+    /// Return a pointer to `_simCore`.
+    std::shared_ptr<simulator::SimCore> getSimCore() { return _simCore; }
+
+
+    /// &&& doc
+    void stop();
+
+    /// &&& doc
+    void join();
+
+    /// &&& doc
+    std::shared_ptr<system::ComControlServer> getComServer() {
+        return _comServer;
+    }
 
 private:
     static Ptr _thisPtr;            ///< Pointer to the global instance of ControlMain.
@@ -61,6 +87,21 @@ private:
 
     /// Private constructor to force the use of `setup()`.
     ControlMain();
+
+    /// &&& doc
+    void _cMain(int argc, const char* argv[]);
+
+    std::thread _mainThrd; ///< &&& doc
+
+    /// Pointer to the system ComControllServer.
+    std::shared_ptr<system::ComControlServer> _comServer;
+
+    /// Point to the simulator instance, if there is one.
+    /// This is only used for testing.
+    std::shared_ptr<simulator::SimCore> _simCore;
+
+    std::atomic<bool> _running{false}; ///< Set to true once the server is running.
+
 };
 
 }  // namespace control

--- a/src/LSST/control/ControlMain.h
+++ b/src/LSST/control/ControlMain.h
@@ -54,17 +54,17 @@ public:
     ControlMain& operator=(ControlMain const&) = delete;
 
     /// Verify threads are stopped and joined.
-    ~ControlMain();
+    ~ControlMain() = default;
 
     /// Return a shared pointer to the global ControlMain instance.
     /// @throws `ConfigException` if `setup` has not already been called.
     static Ptr getPtr();
 
     /// Run the main thread which starts the communication and other threads.
-    void run(int argc, const char* argv[]);
+    void run();
 
     /// Returns true once the server is running.
-    bool getRunning() { return _running; }
+    bool isRunning() { return _running; }
 
     /// Return a pointer to `_simCore`.
     std::shared_ptr<simulator::SimCore> getSimCore() { return _simCore; }
@@ -83,12 +83,10 @@ private:
     static std::mutex _thisPtrMtx;  ///< Protects `_thisPtr`.
 
     /// Private constructor to force the use of `setup()`.
-    ControlMain();
+    ControlMain() = default;
 
     /// The function that runs in the main thread.
-    /// @param argc - unused
-    /// @param argv - unused
-    void _cMain(int argc, const char* argv[]);
+    void _cMain();
 
     /// The main thread, which runs the `_cMain()` function.
     std::thread _mainThrd;

--- a/src/LSST/control/ControlMain.h
+++ b/src/LSST/control/ControlMain.h
@@ -60,7 +60,7 @@ public:
     /// @throws `ConfigException` if `setup` has not already been called.
     static Ptr getPtr();
 
-    /// &&& doc
+    /// Run the main thread which starts the communication and other threads.
     void run(int argc, const char* argv[]);
 
     /// Returns true once the server is running.
@@ -69,17 +69,14 @@ public:
     /// Return a pointer to `_simCore`.
     std::shared_ptr<simulator::SimCore> getSimCore() { return _simCore; }
 
-
-    /// &&& doc
+    /// Stop the communication server threads, which should stop the main thread.
     void stop();
 
-    /// &&& doc
+    /// Join the main thread.
     void join();
 
-    /// &&& doc
-    std::shared_ptr<system::ComControlServer> getComServer() {
-        return _comServer;
-    }
+    /// Return a pointer to the `_comServer`.
+    std::shared_ptr<system::ComControlServer> getComServer() { return _comServer; }
 
 private:
     static Ptr _thisPtr;            ///< Pointer to the global instance of ControlMain.
@@ -88,10 +85,13 @@ private:
     /// Private constructor to force the use of `setup()`.
     ControlMain();
 
-    /// &&& doc
+    /// The function that runs in the main thread.
+    /// @param argc - unused
+    /// @param argv - unused
     void _cMain(int argc, const char* argv[]);
 
-    std::thread _mainThrd; ///< &&& doc
+    /// The main thread, which runs the `_cMain()` function.
+    std::thread _mainThrd;
 
     /// Pointer to the system ComControllServer.
     std::shared_ptr<system::ComControlServer> _comServer;
@@ -100,8 +100,7 @@ private:
     /// This is only used for testing.
     std::shared_ptr<simulator::SimCore> _simCore;
 
-    std::atomic<bool> _running{false}; ///< Set to true once the server is running.
-
+    std::atomic<bool> _running{false};  ///< Set to true once the server is running.
 };
 
 }  // namespace control

--- a/src/LSST/control/FpgaIo.cpp
+++ b/src/LSST/control/FpgaIo.cpp
@@ -55,6 +55,8 @@ void FpgaIo::setup(std::shared_ptr<simulator::SimCore> const& simCore) {
 }
 
 FpgaIo::Ptr FpgaIo::getPtr() {
+    // No mutex needed as once set by `setup()`, the value of _thisPtr
+    // cannot change.
     if (_thisPtr == nullptr) {
         throw system::ConfigException(ERR_LOC, "FpgaIo has not been setup.");
     }

--- a/src/LSST/control/FpgaIo.h
+++ b/src/LSST/control/FpgaIo.h
@@ -89,6 +89,9 @@ public:
     /// Set the loop sleep time in seconds.
     void setLoopSleepSecs(double seconds) { _loopSleepSecs = seconds; }
 
+    /// &&& doc
+    void stopLoop() { _loop = false; }
+
 private:
     static Ptr _thisPtr;            ///< Pointer to the global instance of FpgaIo.
     static std::mutex _thisPtrMtx;  ///< Protects `_thisPtr`.

--- a/src/LSST/control/FpgaIo.h
+++ b/src/LSST/control/FpgaIo.h
@@ -89,7 +89,7 @@ public:
     /// Set the loop sleep time in seconds.
     void setLoopSleepSecs(double seconds) { _loopSleepSecs = seconds; }
 
-    /// &&& doc
+    /// Calling this function will stop the `_fpgaIoThrd` thread.
     void stopLoop() { _loop = false; }
 
 private:

--- a/src/LSST/control/MotionEngine.cpp
+++ b/src/LSST/control/MotionEngine.cpp
@@ -46,6 +46,11 @@ void MotionEngine::setup() {
     _thisPtr = Ptr(new MotionEngine());
 }
 
+MotionEngine::~MotionEngine() {
+    engineStop();
+    engineJoin();
+}
+
 MotionEngine::Ptr MotionEngine::getPtr() {
     if (_thisPtr == nullptr) {
         throw system::ConfigException(ERR_LOC, "MotionEngine has not been setup.");
@@ -93,6 +98,7 @@ void MotionEngine::waitForEngine() const {
 }
 
 bool MotionEngine::engineStop() {
+    LDEBUG("MotionEngine::engineStop _eStopCalled=", to_string(_eStopCalled));
     if (_eStopCalled.exchange(true) == true) {
         LWARN("MotionEngine::engineStop() has already been called");
         return false;
@@ -108,9 +114,12 @@ void MotionEngine::engineJoin() {
         LWARN("MotionEngine::engineJoin() has already been called");
         return;
     }
-
-    _eThrd.join();
-    _timeoutThread.join();
+    if (_eStarted) {
+        _eThrd.join();
+    }
+    if (_timeoutThread.joinable()) {
+        _timeoutThread.join();
+    }
 }
 
 void MotionEngine::queueTimeoutCheck() {

--- a/src/LSST/control/MotionEngine.cpp
+++ b/src/LSST/control/MotionEngine.cpp
@@ -52,6 +52,8 @@ MotionEngine::~MotionEngine() {
 }
 
 MotionEngine::Ptr MotionEngine::getPtr() {
+    // No mutex needed as once set by `setup()`, the value of _thisPtr
+    // cannot change.
     if (_thisPtr == nullptr) {
         throw system::ConfigException(ERR_LOC, "MotionEngine has not been setup.");
     }

--- a/src/LSST/control/MotionEngine.h
+++ b/src/LSST/control/MotionEngine.h
@@ -56,6 +56,12 @@ public:
     /// @throws `ConfigException` if `setup` has not already been called.
     static Ptr getPtr();
 
+    MotionEngine(MotionEngine const&) = delete;
+    MotionEngine& operator=(MotionEngine const&) = delete;
+
+    /// Shutdown the thread if needed.
+    ~MotionEngine();
+
     /// Start the event thread and timeout thread.
     void engineStart();
 

--- a/src/LSST/control/NetCommand.cpp
+++ b/src/LSST/control/NetCommand.cpp
@@ -95,6 +95,13 @@ string NetCommand::getAckJsonStr() { return ackJson.dump(); }
 
 string NetCommand::getRespJsonStr() { return respJson.dump(); }
 
+
+void NetCommand::throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName, JsonPtr const& inJson, json::exception const& ex) const {
+    string eMsg = getCommandName() + " " +funcName + " constructor error in " + inJson->dump() + " what=" + ex.what();
+    LERROR(eMsg);
+    throw NetCommandException(errLoc, eMsg);
+}
+
 NCmdAck::Ptr NCmdAck::create(JsonPtr const& inJson_) {
     auto cmd = Ptr(new NCmdAck(inJson_));
     return cmd;

--- a/src/LSST/control/NetCommand.cpp
+++ b/src/LSST/control/NetCommand.cpp
@@ -95,9 +95,10 @@ string NetCommand::getAckJsonStr() { return ackJson.dump(); }
 
 string NetCommand::getRespJsonStr() { return respJson.dump(); }
 
-
-void NetCommand::throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName, JsonPtr const& inJson, json::exception const& ex) const {
-    string eMsg = getCommandName() + " " +funcName + " constructor error in " + inJson->dump() + " what=" + ex.what();
+void NetCommand::throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName,
+                                          JsonPtr const& inJson, json::exception const& ex) const {
+    string eMsg = getCommandName() + " " + funcName + " constructor error in " + inJson->dump() +
+                  " what=" + ex.what();
     LERROR(eMsg);
     throw NetCommandException(errLoc, eMsg);
 }

--- a/src/LSST/control/NetCommand.h
+++ b/src/LSST/control/NetCommand.h
@@ -141,7 +141,8 @@ protected:
     /// @param funcName - The name of function where the error was caught
     /// @param inJson - The command being handled.
     /// @param ex - The json exception that was caught.
-    void throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName, JsonPtr const& inJson, nlohmann::json::exception const& ex) const;
+    void throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName,
+                                  JsonPtr const& inJson, nlohmann::json::exception const& ex) const;
 
     /// This consturctor is ONLY to be used in createFactoryVersion()/
     /// This constructor makes a dummy version of the object that is only

--- a/src/LSST/control/NetCommand.h
+++ b/src/LSST/control/NetCommand.h
@@ -136,6 +136,13 @@ protected:
     /// @return true if successful.
     virtual bool action() = 0;
 
+    /// Throw a `NetCommandException` using the parameters given.
+    /// @param errLoc - The location where the error was caught.
+    /// @param funcName - The name of function where the error was caught
+    /// @param inJson - The command being handled.
+    /// @param ex - The json exception that was caught.
+    void throwNetCommandException(util::Issue::Context const& errLoc, std::string const& funcName, JsonPtr const& inJson, nlohmann::json::exception const& ex) const;
+
     /// This consturctor is ONLY to be used in createFactoryVersion()/
     /// This constructor makes a dummy version of the object that is only
     /// used to create new instances of that class.

--- a/src/LSST/control/NetCommand.h
+++ b/src/LSST/control/NetCommand.h
@@ -238,17 +238,17 @@ public:
 
     virtual ~NCmdEcho() = default;
 
-    /// @return a version of NCmdAck to be used to generate commands.
+    /// @return a version of NCmdEcho to be used to generate commands.
     static Ptr createFactoryVersion() { return Ptr(new NCmdEcho()); }
 
     /// @return the name of the command this specific class handles.
     std::string getCommandName() const override { return "cmd_echo"; }
 
-    /// @return a new NCmdNoAck object using the parameters in 'inJson'
+    /// @return a new NCmdEcho object using the parameters in 'inJson'
     NetCommand::Ptr createNewNetCommand(JsonPtr const& inJson) override;
 
 protected:
-    // NCmdNoAck always fails
+    /// NCmdEcho echo back the message.
     bool action() override;
 
 private:

--- a/src/LSST/control/NetCommandDefs.cpp
+++ b/src/LSST/control/NetCommandDefs.cpp
@@ -51,7 +51,7 @@ NCmdSwitchCommandSource::NCmdSwitchCommandSource(JsonPtr const& inJson) : NetCom
         _isRemote = inJson->at("isRemote");
         LDEBUG(__func__, " ", getCommandName(), " seqId=", getSeqId(), " isRemote=", _isRemote);
     } catch (json::exception const& ex) {
-        throwNetCommandException(ERR_LOC, __func__,inJson, ex);
+        throwNetCommandException(ERR_LOC, __func__, inJson, ex);
     }
 
     ackJson["id"] = "ack";
@@ -98,7 +98,7 @@ NCmdPower::NCmdPower(JsonPtr const& inJson) : NetCommand(inJson) {
         LDEBUG(__func__, " ", getCommandName(), " seqId=", getSeqId(), " powerType=", _powerType, " ",
                getPowerSystemTypeStr(_powerType), " status=", _status);
     } catch (json::exception const& ex) {
-        throwNetCommandException(ERR_LOC, __func__,inJson, ex);
+        throwNetCommandException(ERR_LOC, __func__, inJson, ex);
     }
     ackJson["id"] = "ack";
     ackJson["user_info"] = getCommandName() + " " + getPowerSystemTypeStr(_powerType) + to_string(_status);

--- a/src/LSST/control/NetCommandDefs.cpp
+++ b/src/LSST/control/NetCommandDefs.cpp
@@ -27,6 +27,9 @@
 // Third party headers
 
 // Project headers
+#include "control/Context.h"
+#include "control/PowerSystem.h"
+#include "state/Model.h"
 #include "system/ComControlServer.h"
 #include "system/Globals.h"
 #include "util/Log.h"
@@ -46,25 +49,25 @@ NCmdSwitchCommandSource::Ptr NCmdSwitchCommandSource::create(JsonPtr const& inJs
 NCmdSwitchCommandSource::NCmdSwitchCommandSource(JsonPtr const& inJson) : NetCommand(inJson) {
     try {
         _isRemote = inJson->at("isRemote");
-        LDEBUG("NCmdSwitchCommandSource seqId=", getSeqId(), " isRemote=", _isRemote);
+        LDEBUG(__func__, " ", getCommandName()," seqId=", getSeqId(), " isRemote=", _isRemote);
     } catch (json::exception const& ex) {
-        string eMsg = string("NCmdEcho constructor error in ") + inJson->dump() + " what=" + ex.what();
+        string eMsg = string(__func__) + " constructor error in " + inJson->dump() + " what=" + ex.what();
         LERROR(eMsg);
         throw NetCommandException(ERR_LOC, eMsg);
     }
 
     ackJson["id"] = "ack";
-    ackJson["user_info"] = "switchCommandSource " + to_string(_isRemote);
+    ackJson["user_info"] = getCommandName() + " " + to_string(_isRemote);
 }
 
 NetCommand::Ptr NCmdSwitchCommandSource::createNewNetCommand(JsonPtr const& inJson) {
-    NCmdSwitchCommandSource::Ptr cmd = NCmdSwitchCommandSource::create(inJson);
-    return cmd;
+    return NCmdSwitchCommandSource::create(inJson);
 }
 
 bool NCmdSwitchCommandSource::action() {
     bool result = system::Globals::get().setCommandSourceIsRemote(_isRemote);
     // This sets the CommandableByDds global, which needs to be broadcast.
+    // This could be a duplicate broadcast, which is expected to be harmless.
     string msg = to_string(system::Globals::get().getCommandableByDdsJson());
     auto comServ = system::ComControlServer::get().lock();
     if (comServ != nullptr) {
@@ -72,6 +75,91 @@ bool NCmdSwitchCommandSource::action() {
     }
     return result;
 }
+
+
+NCmdPower::Ptr NCmdPower::create(JsonPtr const& inJson_) {
+    auto cmd = Ptr(new NCmdPower(inJson_));
+    return cmd;
+}
+
+NCmdPower::NCmdPower(JsonPtr const& inJson) : NetCommand(inJson) {
+    LTRACE("NCmdPower::NCmdPower ", to_string(*inJson));
+    try {
+        int powerType = inJson->at("powerType");
+        switch (powerType) {
+        case MOTOR:
+            _powerType = MOTOR;
+            break;
+        case COMM:
+            _powerType = COMM;
+            break;
+        default:
+            throw NetCommandException(ERR_LOC, "unknown powerType=" + to_string(powerType) + " in " + inJson->dump());
+        }
+        _status = inJson->at("status");
+        LDEBUG(__func__, " ", getCommandName()," seqId=", getSeqId(), " powerType=", _powerType, " ", getPowerSystemTypeStr(_powerType), " status=", _status);
+    } catch (json::exception const& ex) {
+        string eMsg = string(__func__) + " constructor error in " + inJson->dump() + " what=" + ex.what();
+        LERROR(eMsg);
+        throw NetCommandException(ERR_LOC, eMsg); // &&& make a base class function to do this
+    }
+    ackJson["id"] = "ack";
+    ackJson["user_info"] = getCommandName() + " " + getPowerSystemTypeStr(_powerType) + to_string(_status);
+}
+
+NetCommand::Ptr NCmdPower::createNewNetCommand(JsonPtr const& inJson) {
+    return NCmdPower::create(inJson);
+}
+
+bool NCmdPower::action() {
+    auto context = Context::get();
+    bool result = context->model.getCurrentState()->cmdPower(_powerType, _status);
+    {
+        // Message that looks something like this needs to be broadcast
+        // {'powerType': 2, 'status': True, 'id': 'cmd_power', 'sequence_id': 123}
+        // {'id': 'powerSystemState', 'powerType': 2, 'status': true, 'state': 3 }
+        // {'id': 'powerSystemState', 'powerType': 2, 'status': true, 'state': 5}
+        // This is a duplicate broadcast and can probably be removed, but it may
+        // be useful as without this motor state is only broadcast on change.
+        json js = context->model.getPowerSystem()->getPowerSystemStateJson(_powerType);
+        string msg = to_string(js);
+        auto comServ = system::ComControlServer::get().lock();
+        if (comServ != nullptr) {
+            comServ->asyncWriteToAllComConn(msg);
+        }
+    }
+    return result;
+}
+
+NCmdSystemShutdown::Ptr NCmdSystemShutdown::create(JsonPtr const& inJson_) {
+    auto cmd = Ptr(new NCmdSystemShutdown(inJson_));
+    return cmd;
+}
+
+NCmdSystemShutdown::NCmdSystemShutdown(JsonPtr const& inJson) : NetCommand(inJson) {
+
+    ackJson["id"] = "ack";
+    ackJson["user_info"] = getCommandName();
+}
+
+NetCommand::Ptr NCmdSystemShutdown::createNewNetCommand(JsonPtr const& inJson) {
+    return NCmdSystemShutdown::create(inJson);
+}
+
+bool NCmdSystemShutdown::action() {
+    LINFO("NCmdSystemShutdown");
+    thread thrd([]{
+            sleep(1);
+            LINFO("NCmdSystemShutdown shutting down");
+            auto context = Context::get();
+            context->model.systemShutdown();
+            sleep(1);
+            exit(0); //FUTURE: exit() should not be needed. // &&&
+    });
+    thrd.detach();
+    return true;
+}
+
 
 }  // namespace control
 }  // namespace m2cellcpp

--- a/src/LSST/control/NetCommandDefs.cpp
+++ b/src/LSST/control/NetCommandDefs.cpp
@@ -147,8 +147,6 @@ bool NCmdSystemShutdown::action() {
         LINFO("NCmdSystemShutdown shutting down");
         auto context = Context::get();
         context->model.systemShutdown();
-        sleep(1);
-        exit(0);  // FUTURE: exit() should not be needed. // &&&
     });
     thrd.detach();
     return true;

--- a/src/LSST/control/NetCommandDefs.h
+++ b/src/LSST/control/NetCommandDefs.h
@@ -70,7 +70,6 @@ private:
     bool _isRemote = 1;  ///< Value of "isRemote" section of message.
 };
 
-
 /// This class handles the "cmd_power" message.
 /// - "powerType" must be `1` (for MOTOR) or `2` (for COMM) (see PowerSystemType).
 /// - "status" `true` indicates the "powerType" should be turned on, while `false` turns it off.
@@ -112,7 +111,6 @@ private:
     bool _status = false;
 };
 
-
 /// This class handles the "cmd_systemShutdown" message.
 /// Expected message form is: {'id': 'cmd_systemShutdown', 'sequence_id': 123}
 /// This would shutdown the entire system.
@@ -144,7 +142,6 @@ private:
     NCmdSystemShutdown(JsonPtr const& json);
     NCmdSystemShutdown() : NetCommand() {}
 };
-
 
 }  // namespace control
 }  // namespace m2cellcpp

--- a/src/LSST/control/NetCommandDefs.h
+++ b/src/LSST/control/NetCommandDefs.h
@@ -67,12 +67,15 @@ private:
     NCmdSwitchCommandSource(JsonPtr const& json);
     NCmdSwitchCommandSource() : NetCommand() {}
 
-    bool _isRemote = 1;  ///< Value of "isRemote" section of message.
+    bool _isRemote = true;  ///< Value of "isRemote" section of message. //&&&
 };
 
-/// This class handles the "cmd_power" message.
+/// This class handles the "cmd_power" json message from a client.
+/// The json message requires:
+/// - "id" must be "cmd_power"
 /// - "powerType" must be `1` (for MOTOR) or `2` (for COMM) (see PowerSystemType).
 /// - "status" `true` indicates the "powerType" should be turned on, while `false` turns it off.
+/// - "sequence_id" integer that is unique to the client.
 /// - MOTOR power should never be on if COMM power is not on.
 /// Expected message form is: {'powerType': 2, 'status': true, 'id': 'cmd_power', 'sequence_id': 123}
 /// This would turn on COMM power.

--- a/src/LSST/control/NetCommandDefs.h
+++ b/src/LSST/control/NetCommandDefs.h
@@ -34,8 +34,8 @@ namespace m2cellcpp {
 namespace control {
 
 /// This class is used to handle the "cmd_switchCommandSource" command.
-/// The "isRemote" item indicates that the GUI should be used when the value is `true`.
-/// `false` would indicate the use of SAL.
+/// The "isRemote" item indicates that the GUI should be used when the value is `false`.
+/// `true` would indicate the use of SAL.
 /// For the purposes of m2cellcpp, "isRemote" should always be true.
 /// Expected message form is: {"isRemote": true, "id": "cmd_switchCommandSource", "sequence_id": 123}
 ///
@@ -67,7 +67,7 @@ private:
     NCmdSwitchCommandSource(JsonPtr const& json);
     NCmdSwitchCommandSource() : NetCommand() {}
 
-    bool _isRemote = true;  ///< Value of "isRemote" section of message. //&&&
+    bool _isRemote = true;  ///< Value of "isRemote" section of message.
 };
 
 /// This class handles the "cmd_power" json message from a client.

--- a/src/LSST/control/NetCommandDefs.h
+++ b/src/LSST/control/NetCommandDefs.h
@@ -26,14 +26,17 @@
 // Third party headers
 
 // Project headers
+#include "control/control_defs.h"
 #include "control/NetCommand.h"
 
 namespace LSST {
 namespace m2cellcpp {
 namespace control {
 
-/// This class sends back the `inJson["msg"]` value in `respJson["msg"]`.
-/// `inJson["msg"]` is a required field for this command.
+/// This class is used to handle the "cmd_switchCommandSource" command.
+/// The "isRemote" item indicates that the GUI should be used when the value is `true`.
+/// `false` would indicate the use of SAL.
+/// For the purposes of m2cellcpp, "isRemote" should always be true.
 /// Expected message form is: {"isRemote": true, "id": "cmd_switchCommandSource", "sequence_id": 123}
 ///
 /// unit test: test_NetCommand.cpp
@@ -56,7 +59,8 @@ public:
     NetCommand::Ptr createNewNetCommand(JsonPtr const& inJson) override;
 
 protected:
-    // NCmdNoAck always fails
+    /// Set the value of `Globals::_commandableByDds` to the value of "isRemote",
+    /// and broadcasts the new value to all clients.
     bool action() override;
 
 private:
@@ -65,6 +69,82 @@ private:
 
     bool _isRemote = 1;  ///< Value of "isRemote" section of message.
 };
+
+
+/// This class handles the "cmd_power" message.
+/// - "powerType" must be `1` (for MOTOR) or `2` (for COMM) (see PowerSystemType).
+/// - "status" `true` indicates the "powerType" should be turned on, while `false` turns it off.
+/// - MOTOR power should never be on if COMM power is not on.
+/// Expected message form is: {'powerType': 2, 'status': true, 'id': 'cmd_power', 'sequence_id': 123}
+/// This would turn on COMM power.
+///
+/// unit test: test_startup_shutdown.cpp
+class NCmdPower : public NetCommand {
+public:
+    using Ptr = std::shared_ptr<NCmdPower>;
+
+    /// @return a new NCmdPower object based on inJson.
+    static Ptr create(JsonPtr const& inJson);
+
+    virtual ~NCmdPower() = default;
+
+    /// @return a version of NCmdPower to be used to generate commands.
+    static Ptr createFactoryVersion() { return Ptr(new NCmdPower()); }
+
+    /// @return the name of the command this specific class handles.
+    std::string getCommandName() const override { return "cmd_power"; }
+
+    /// @return a new NCmdPower object using the parameters in 'inJson'
+    NetCommand::Ptr createNewNetCommand(JsonPtr const& inJson) override;
+
+protected:
+    /// Turn the `MOTOR` or `COMM` power on or off.
+    bool action() override;
+
+private:
+    NCmdPower(JsonPtr const& json);
+    NCmdPower() : NetCommand() {}
+
+    /// Value of "powerType" section of message, where 1 is `MOTOR` and 2 is `COMM`.
+    PowerSystemType _powerType = PowerSystemType::MOTOR;
+    /// Value of "status" section of message, where `true` means turn on, and `false`
+    /// means turn off.
+    bool _status = false;
+};
+
+
+/// This class handles the "cmd_systemShutdown" message.
+/// Expected message form is: {'id': 'cmd_systemShutdown', 'sequence_id': 123}
+/// This would shutdown the entire system.
+///
+/// unit test: test_startup_shutdown.cpp
+class NCmdSystemShutdown : public NetCommand {
+public:
+    using Ptr = std::shared_ptr<NCmdSystemShutdown>;
+
+    /// @return a new NCmdSystemShutdown object based on inJson.
+    static Ptr create(JsonPtr const& inJson);
+
+    virtual ~NCmdSystemShutdown() = default;
+
+    /// @return a version of NCmdSystemShutdown to be used to generate commands.
+    static Ptr createFactoryVersion() { return Ptr(new NCmdSystemShutdown()); }
+
+    /// @return the name of the command this specific class handles.
+    std::string getCommandName() const override { return "cmd_systemShutdown"; }
+
+    /// @return a new NCmdSystemShutdown object using the parameters in 'inJson'
+    NetCommand::Ptr createNewNetCommand(JsonPtr const& inJson) override;
+
+protected:
+    /// Shutdown the entire system.
+    bool action() override;
+
+private:
+    NCmdSystemShutdown(JsonPtr const& json);
+    NCmdSystemShutdown() : NetCommand() {}
+};
+
 
 }  // namespace control
 }  // namespace m2cellcpp

--- a/src/LSST/control/PowerSubsystem.cpp
+++ b/src/LSST/control/PowerSubsystem.cpp
@@ -295,10 +295,7 @@ PowerSubsystem::PowerSubsystem(PowerSystemType sysType)
     _reportStateChange();
 }
 
-void PowerSubsystem::setContext(std::shared_ptr<Context> const& context) {
-    _context = context;
-}
-
+void PowerSubsystem::setContext(std::shared_ptr<Context> const& context) { _context = context; }
 
 double PowerSubsystem::getVoltage() const {
     switch (_systemType) {

--- a/src/LSST/control/PowerSubsystem.h
+++ b/src/LSST/control/PowerSubsystem.h
@@ -335,7 +335,6 @@ private:
 /// unit tests: test_PowerSystem.cpp
 class PowerSubsystem {
 public:
-
     PowerSubsystem() = delete;
     PowerSubsystem(PowerSubsystem const&) = delete;
     PowerSubsystem& operator=(PowerSubsystem const&) = delete;
@@ -394,7 +393,8 @@ public:
     /// Return the target power state.
     PowerState getTargPowerState() const;
 
-    /// &&& doc
+    /// Return a json message that describes the state of this instance.
+    /// The message is appropriate to be sent to TCP/IP clients.
     nlohmann::json getPowerSystemStateJson() const;
 
 private:
@@ -450,10 +450,11 @@ private:
     /// Return true if the FaultMgr has any faults that affect this PowerSubsystem.
     bool _checkForFaults();
 
-    /// &&& doc
+    /// Calling this will indicate to the `Model` that the state of this object has changed.
     void _reportStateChange() const;
 
-    /// &&& doc
+    /// Return a json message that describes the state of this instance.
+    /// The message is appropriate to be sent to TCP/IP clients.
     nlohmann::json _getPowerSystemStateJson() const;
 
     PowerSystemType _systemType;  ///< indicates if this is the MOTOR or COMM system.

--- a/src/LSST/control/PowerSystem.cpp
+++ b/src/LSST/control/PowerSystem.cpp
@@ -239,8 +239,9 @@ nlohmann::json PowerSystem::getPowerSystemStateJson(PowerSystemType powerType) c
             return _motor.getPowerSystemStateJson();
         case COMM:
             return _comm.getPowerSystemStateJson();
+        default:
+            throw util::Bug(ERR_LOC, "unexpected powerType=" + to_string(powerType));
     }
-    throw util::Bug(ERR_LOC, "unexpected powerType=" + to_string(powerType));
 }
 
 }  // namespace control

--- a/src/LSST/control/PowerSystem.cpp
+++ b/src/LSST/control/PowerSystem.cpp
@@ -57,7 +57,6 @@ PowerSystem::PowerSystem() : _motor(MOTOR), _comm(COMM) {
 void PowerSystem::setContext(std::shared_ptr<Context> const& context) {
     _comm.setContext(context);
     _motor.setContext(context);
-
 }
 
 PowerSystem::~PowerSystem() {
@@ -125,7 +124,6 @@ bool PowerSystem::_checkTimeout(double diffInSeconds) {
     return timedOut;
 }
 
-
 bool PowerSystem::powerMotor(bool on) {
     bool target = on;
     if (on && _comm.getActualPowerState() != PowerState::ON) {
@@ -141,7 +139,6 @@ bool PowerSystem::powerMotor(bool on) {
     }
 }
 
-
 bool PowerSystem::powerComm(bool on) {
     auto actualMotorState = _motor.getActualPowerState();
     if (!on && actualMotorState != PowerState::OFF) {
@@ -154,7 +151,6 @@ bool PowerSystem::powerComm(bool on) {
         return true;
     }
 }
-
 
 void PowerSystem::_processDaq(SysInfo info) {
     faultmgr::FaultStatusBits currentFaults;
@@ -239,10 +235,10 @@ void PowerSystem::_processDaqHealthTelemetry(SysInfo sInfo, faultmgr::FaultStatu
 
 nlohmann::json PowerSystem::getPowerSystemStateJson(PowerSystemType powerType) const {
     switch (powerType) {
-    case MOTOR:
-        return _motor.getPowerSystemStateJson();
-    case COMM:
-        return _comm.getPowerSystemStateJson();
+        case MOTOR:
+            return _motor.getPowerSystemStateJson();
+        case COMM:
+            return _comm.getPowerSystemStateJson();
     }
     throw util::Bug(ERR_LOC, "unexpected powerType=" + to_string(powerType));
 }

--- a/src/LSST/control/PowerSystem.h
+++ b/src/LSST/control/PowerSystem.h
@@ -76,7 +76,8 @@ public:
     /// Try to turn off power and stop the event thread.
     virtual ~PowerSystem();
 
-    /// &&& doc
+    /// Use this to set this object's pointer to context to the global `context` instance.
+    /// In some unit tests, there may be no `Context` instance.
     void setContext(std::shared_ptr<Context> const& context);
 
     /// Called when new system information is available so this
@@ -91,13 +92,22 @@ public:
     /// If `set` is true, enable the interlock, otherwise disable it.
     void writeCrioInterlockEnable(bool set);
 
-    /// &&& doc
+    /// Turn motor power on or off.
     /// Motor power can only be turned on if Comm power is already ON.
+    /// @param on - Turn power on if true, or off if it is false.
+    /// @return true if there wasn't anything preventing power from being changed.
+    ///   This only indicates that the power bit could be set. There may be
+    ///   other issue that prevent power from reaching the `ON` state.
     bool powerMotor(bool on);
 
-    /// &&& doc
-    /// If comm power is being turned off, then motor power must also be
-    /// turned off.
+    /// Turn comm power on or off.
+    /// @param on - Turn power on if true, or off if it is false.
+    /// @return true if there wasn't anything preventing power from being changed.
+    ///   This only indicates that the power bit could be set. There may be
+    ///   other issue that prevent power from reaching the `ON` state.
+    /// If comm power is being turned off, then motor power should already be
+    /// turned off. In any case, if the comm power bit is turned off,
+    /// `PowerSystem` will try to turn off motor power.
     bool powerComm(bool on);
 
     /// Return a reference to the MOTOR PowerSubSystem.
@@ -106,13 +116,13 @@ public:
     /// Return a reference to the COMM PowerSubSystem.
     PowerSubsystem& getComm() { return _comm; }
 
-    /// &&& doc
+    /// Provide a json message containting the state of a `PowerSubsystem`.
+    /// @param powerType - indicates which subsystem to generate a json message for.
+    /// @return a json message describing the state of the `PowerSubsystem` indicated by `powerType`.
     nlohmann::json getPowerSystemStateJson(PowerSystemType powerType) const;
 
-    /// &&& doc
-    void stopTimeoutLoop() {
-        _timeoutLoop = false;
-    }
+    /// Calling this function will stop the timeout thread.
+    void stopTimeoutLoop() { _timeoutLoop = false; }
 
 private:
     /// Read SysInfo from the FPGA and call `_processDaq`

--- a/src/LSST/control/control_defs.cpp
+++ b/src/LSST/control/control_defs.cpp
@@ -1,0 +1,115 @@
+/*
+ * This file is part of LSST ts_m2cellcpp test suite.
+ *
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Class header
+#include "control/control_defs.h"
+
+// system headers
+
+// project headers
+
+using namespace std;
+
+namespace LSST {
+namespace m2cellcpp {
+namespace control {
+
+string getSysStatusStr(SysStatus sta) {
+    switch (sta) {
+        case GOOD:
+            return "GOOD";
+        case WAITING:
+            return "WATIING";
+        case WARN:
+            return "WARN";
+        case FAULT:
+            return "FAULT";
+        case CRITICAL:
+            return "CRITICAL";
+    }
+    return "unknown";
+}
+
+string getPowerSystemTypeStr(PowerSystemType sysT) {
+    switch (sysT) {
+        case MOTOR:
+            return "MOTOR";
+        case COMM:
+            return "COMM";
+        case UNKNOWNPOWERSYSTEM:
+            return "UNKNOWNPOWERSYSTEM";
+    }
+    return "unknown";
+}
+
+PowerSystemType intToPowerSystemType(int val) {
+    switch (val) {
+        case MOTOR:
+            return MOTOR;
+        case COMM:
+            return COMM;
+        default:
+            return UNKNOWNPOWERSYSTEM;
+    }
+}
+
+string getPowerStateOldStr(PowerState sysState) {
+    switch (sysState) {
+        case UNKNOWN:
+            return "Init";
+        case OFF:
+            return "PoweredOff";
+        case TURNING_ON:
+            return "PoweringOn";
+        case RESET:
+            return "ResettingBreakers";
+        case ON:
+            return "PoweredOn";
+        case TURNING_OFF:
+            return "PoweringOff";
+    }
+    return "unknown";
+}
+
+string getPowerStateStr(PowerState powerState) {
+    int val = powerState;
+    string valStr = string(" ") + to_string(val);
+    switch (powerState) {
+        case ON:
+            return "ON" + valStr;
+        case TURNING_ON:
+            return "TURNING_ON" + valStr;
+        case TURNING_OFF:
+            return "TURNING_OFF" + valStr;
+        case OFF:
+            return "OFF" + valStr;
+        case RESET:
+            return "RESET" + valStr;
+        case UNKNOWN:
+            return "UNKNOWN" + valStr;
+    }
+    return "unknown" + valStr;
+}
+
+}  // namespace control
+}  // namespace m2cellcpp
+}  // namespace LSST

--- a/src/LSST/control/control_defs.h
+++ b/src/LSST/control/control_defs.h
@@ -38,35 +38,17 @@ namespace control {
 enum SysStatus { CRITICAL = -3, FAULT = -2, WARN = -1, GOOD = 0, WAITING = 1 };
 
 /// Return a string representation of the SysStatus enum `sta`.
-inline std::string getSysStatusStr(SysStatus sta) {
-    switch (sta) {
-        case GOOD:
-            return "GOOD";
-        case WAITING:
-            return "WATIING";
-        case WARN:
-            return "WARN";
-        case FAULT:
-            return "FAULT";
-        case CRITICAL:
-            return "CRITICAL";
-    }
-    return "unknown";
-}
+std::string getSysStatusStr(SysStatus sta);
 
 /// Power system type enum, the values should match those used by "cmd_power".
-enum PowerSystemType { MOTOR = 1, COMM = 2 };
+enum PowerSystemType { MOTOR = 1, COMM = 2, UNKNOWNPOWERSYSTEM = 3 };
 
 /// Return a string version of `sysT`.
-inline std::string getPowerSystemTypeStr(PowerSystemType sysT) {
-    switch (sysT) {
-        case MOTOR:
-            return "MOTOR";
-        case COMM:
-            return "COMM";
-    }
-    return "unknown";
-}
+std::string getPowerSystemTypeStr(PowerSystemType sysT);
+
+/// Convert an integer to PowerSystemType, any value not `MOTOR` or `COMM`
+/// will be returned as `UNKNOWNPOWERSYSTEM`
+PowerSystemType intToPowerSystemType(int val);
 
 /// PowerSystemState, values must match lsst-ts/ts_xml/python/lsst/ts/xml/enums/MTM2.py
 // PowerSystemState { INIT = 1, POWEREDOFF = 2, POWERINGON = 3, RESETTINGBREAKERS = 4, POWEREDON = 5,
@@ -74,43 +56,11 @@ inline std::string getPowerSystemTypeStr(PowerSystemType sysT) {
 enum PowerState { UNKNOWN = 1, OFF = 2, TURNING_ON = 3, RESET = 4, ON = 5, TURNING_OFF = 6 };
 
 /// Return a string version of `sysState` to be used in TCP/IP communications.
-inline std::string getPowerStateOldStr(PowerState sysState) {
-    switch (sysState) {
-        case UNKNOWN:
-            return "Init";
-        case OFF:
-            return "PoweredOff";
-        case TURNING_ON:
-            return "PoweringOn";
-        case RESET:
-            return "ResettingBreakers";
-        case ON:
-            return "PoweredOn";
-        case TURNING_OFF:
-            return "PoweringOff";
-    }
-    return "unknown";
-}
+std::string getPowerStateOldStr(PowerState sysState);
 
-inline std::string getPowerStateStr(PowerState powerState) {
-    int val = powerState;
-    std::string valStr = std::string(" ") + std::to_string(val);
-    switch (powerState) {
-        case ON:
-            return "ON" + valStr;
-        case TURNING_ON:
-            return "TURNING_ON" + valStr;
-        case TURNING_OFF:
-            return "TURNING_OFF" + valStr;
-        case OFF:
-            return "OFF" + valStr;
-        case RESET:
-            return "RESET" + valStr;
-        case UNKNOWN:
-            return "UNKNOWN" + valStr;
-    }
-    return "unknown" + valStr;
-}
+/// Return a string version of PowerSystemState that matches the enum value and
+/// is similar to those found LabView code.
+std::string getPowerStateStr(PowerState powerState);
 
 }  // namespace control
 }  // namespace m2cellcpp

--- a/src/LSST/control/control_defs.h
+++ b/src/LSST/control/control_defs.h
@@ -54,8 +54,8 @@ inline std::string getSysStatusStr(SysStatus sta) {
     return "unknown";
 }
 
-/// Power system type enum.
-enum PowerSystemType { MOTOR = 0, COMM = 1 };
+/// Power system type enum, the values should match those used by "cmd_power".
+enum PowerSystemType { MOTOR = 1, COMM = 2 };
 
 /// Return a string version of `sysT`.
 inline std::string getPowerSystemTypeStr(PowerSystemType sysT) {
@@ -65,7 +65,44 @@ inline std::string getPowerSystemTypeStr(PowerSystemType sysT) {
         case COMM:
             return "COMM";
     }
-    return "unknown ";
+    return "unknown";
+}
+
+/// PowerSystemState, values must match lsst-ts/ts_xml/python/lsst/ts/xml/enums/MTM2.py
+// PowerSystemState { INIT = 1, POWEREDOFF = 2, POWERINGON = 3, RESETTINGBREAKERS = 4, POWEREDON = 5, POWERINGOFF = 6 };
+enum PowerState { UNKNOWN = 1, OFF = 2, TURNING_ON = 3, RESET = 4, ON = 5, TURNING_OFF = 6};
+
+/// Return a string version of `sysState` to be used in TCP/IP communications.
+inline std::string getPowerStateOldStr(PowerState sysState) {
+    switch (sysState) {
+    case UNKNOWN: return "Init";
+    case OFF: return "PoweredOff";
+    case TURNING_ON: return "PoweringOn";
+    case RESET: return "ResettingBreakers";
+    case ON: return "PoweredOn";
+    case TURNING_OFF: return "PoweringOff";
+    }
+    return "unknown";
+}
+
+inline std::string getPowerStateStr(PowerState powerState) {
+    int val = powerState;
+    std::string valStr = std::string(" ") + std::to_string(val);
+    switch (powerState) {
+        case ON:
+            return "ON" + valStr;
+        case TURNING_ON:
+            return "TURNING_ON" + valStr;
+        case TURNING_OFF:
+            return "TURNING_OFF" + valStr;
+        case OFF:
+            return "OFF" + valStr;
+        case RESET:
+            return "RESET" + valStr;
+        case UNKNOWN:
+            return "UNKNOWN" + valStr;
+    }
+    return "unknown" + valStr;
 }
 
 }  // namespace control

--- a/src/LSST/control/control_defs.h
+++ b/src/LSST/control/control_defs.h
@@ -69,18 +69,25 @@ inline std::string getPowerSystemTypeStr(PowerSystemType sysT) {
 }
 
 /// PowerSystemState, values must match lsst-ts/ts_xml/python/lsst/ts/xml/enums/MTM2.py
-// PowerSystemState { INIT = 1, POWEREDOFF = 2, POWERINGON = 3, RESETTINGBREAKERS = 4, POWEREDON = 5, POWERINGOFF = 6 };
-enum PowerState { UNKNOWN = 1, OFF = 2, TURNING_ON = 3, RESET = 4, ON = 5, TURNING_OFF = 6};
+// PowerSystemState { INIT = 1, POWEREDOFF = 2, POWERINGON = 3, RESETTINGBREAKERS = 4, POWEREDON = 5,
+// POWERINGOFF = 6 };
+enum PowerState { UNKNOWN = 1, OFF = 2, TURNING_ON = 3, RESET = 4, ON = 5, TURNING_OFF = 6 };
 
 /// Return a string version of `sysState` to be used in TCP/IP communications.
 inline std::string getPowerStateOldStr(PowerState sysState) {
     switch (sysState) {
-    case UNKNOWN: return "Init";
-    case OFF: return "PoweredOff";
-    case TURNING_ON: return "PoweringOn";
-    case RESET: return "ResettingBreakers";
-    case ON: return "PoweredOn";
-    case TURNING_OFF: return "PoweringOff";
+        case UNKNOWN:
+            return "Init";
+        case OFF:
+            return "PoweredOff";
+        case TURNING_ON:
+            return "PoweringOn";
+        case RESET:
+            return "ResettingBreakers";
+        case ON:
+            return "PoweredOn";
+        case TURNING_OFF:
+            return "PoweringOff";
     }
     return "unknown";
 }

--- a/src/LSST/faultmgr/FaultMgr.cpp
+++ b/src/LSST/faultmgr/FaultMgr.cpp
@@ -55,6 +55,8 @@ void FaultMgr::setup() {
 }
 
 FaultMgr::Ptr FaultMgr::getPtr() {
+    // No mutex needed as once set by `setup()`, the value of _thisPtr
+    // cannot change.
     if (_thisPtr == nullptr) {
         throw system::ConfigException(ERR_LOC, "FaultMgr has not been setup.");
     }

--- a/src/LSST/faultmgr/FaultMgr.cpp
+++ b/src/LSST/faultmgr/FaultMgr.cpp
@@ -232,7 +232,7 @@ FaultStatusBits FaultMgr::getFaultEnableMask() const {
 
 void FaultMgr::_updateTelemetryCom(BasicFaultMgr const& newFsbSummary) {
     // TODO: DM-41751 send information to telemetry TCP/IP server
-    LCRITICAL("FaultMgr::_updateTelemetry NEEDS CODE");
+    LDEBUG("FaultMgr::_updateTelemetry NEEDS CODE");
 }
 
 void FaultMgr::faultMsg(int errId, std::string const& eMsg) {

--- a/src/LSST/faultmgr/FaultStatusBits.cpp
+++ b/src/LSST/faultmgr/FaultStatusBits.cpp
@@ -260,9 +260,10 @@ uint64_t FaultStatusBits::getMaskPowerSubsystemFaults(control::PowerSystemType s
             }
             return _maskSubsystemMotorFault->_bitmap;
         }
+        default:
+            throw util::Bug(ERR_LOC, string("FaultStatusBits::getMaskPowerSubsystemFaults ") +
+                                             getPowerSystemTypeStr(sysType) + " unexpected type");
     }
-    throw util::Bug(ERR_LOC, string("FaultStatusBits::getMaskPowerSubsystemFaults ") +
-                                     getPowerSystemTypeStr(sysType) + " unexpected type");
 }
 
 uint64_t FaultStatusBits::getTelemetryFaultManagerAffectedFaultMask() {

--- a/src/LSST/simulator/SimCore.cpp
+++ b/src/LSST/simulator/SimCore.cpp
@@ -73,12 +73,10 @@ SimCore::SimCore() {
     _inputPort->setBitAtPos(control::InputPortBits::POWER_SUPPLY_2_CURRENT_OK, true);
 }
 
-
 SimCore::~SimCore() {
     stop();
     join();
 }
-
 
 void SimCore::_simRun() {
     control::OutputPortBits prevOutput = *_outputPort;

--- a/src/LSST/simulator/SimCore.h
+++ b/src/LSST/simulator/SimCore.h
@@ -58,6 +58,12 @@ public:
 
     SimCore();
 
+    SimCore(SimCore const&) = delete;
+    SimCore& operator=(SimCore const&) = delete;
+
+    /// Destructor stop and join thread if not already done.
+    ~SimCore();
+
     /// Get a copy of the `_newOutputPort`
     control::OutputPortBits getNewOutputPort();
 
@@ -82,7 +88,7 @@ public:
     void stop() { _simLoop = false; }
 
     /// Join the simulation thread.
-    bool join();
+    void join();
 
     /// Write the value of `_inputPort` bit at `pos` to 1 if
     /// `set` is true or 0  if `set` is false.
@@ -127,6 +133,8 @@ private:
     std::atomic<uint64_t> _iterations{0};  ///< number of times through the `_simRun` loop.
 
     util::CLOCK::time_point _prevTimeStamp;  ///< Last time through the `_simRun` loop.
+
+    std::atomic<bool> _joined{false}; ///< Latch for `join()` function.
 };
 
 }  // namespace simulator

--- a/src/LSST/simulator/SimCore.h
+++ b/src/LSST/simulator/SimCore.h
@@ -134,7 +134,7 @@ private:
 
     util::CLOCK::time_point _prevTimeStamp;  ///< Last time through the `_simRun` loop.
 
-    std::atomic<bool> _joined{false}; ///< Latch for `join()` function.
+    std::atomic<bool> _joined{false};  ///< Latch for `join()` function.
 };
 
 }  // namespace simulator

--- a/src/LSST/state/IdleState.cpp
+++ b/src/LSST/state/IdleState.cpp
@@ -40,17 +40,14 @@ IdleState::Ptr IdleState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
+
 void IdleState::enterState(State::Ptr const& oldState) {
-    string msg("IdleState::enterState " + getName());
-    LINFO(msg);
+    enterStateBase(oldState);
 }
 
-bool IdleState::setPower(bool on) {
-    if (modelPtr == nullptr) {
-        LERROR("IdleState modelPtr is NULL");
-        return false;
-    }
-    return modelPtr->_setPower(on);
+
+bool IdleState::cmdPower(control::PowerSystemType powerType, bool on) {
+    return cmdPowerBase(powerType, on);
 }
 
 }  // namespace state

--- a/src/LSST/state/IdleState.cpp
+++ b/src/LSST/state/IdleState.cpp
@@ -40,15 +40,9 @@ IdleState::Ptr IdleState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
+void IdleState::enterState(State::Ptr const& oldState) { enterStateBase(oldState); }
 
-void IdleState::enterState(State::Ptr const& oldState) {
-    enterStateBase(oldState);
-}
-
-
-bool IdleState::cmdPower(control::PowerSystemType powerType, bool on) {
-    return cmdPowerBase(powerType, on);
-}
+bool IdleState::cmdPower(control::PowerSystemType powerType, bool on) { return cmdPowerBase(powerType, on); }
 
 }  // namespace state
 }  // namespace m2cellcpp

--- a/src/LSST/state/IdleState.h
+++ b/src/LSST/state/IdleState.h
@@ -66,7 +66,7 @@ public:
     // VI-PH  resumeScriptVI // calls Model::resumeScriptVI
 
     /// VI setPowerVI // calls Model::setPowerVI(CommPowerControl, MotorPowerControl)
-    bool setPower(bool on) override;
+    bool cmdPower(control::PowerSystemType powerType, bool on) override;
 
     // VI-PH  shutdownCellCommVI // calls Model::shutdownCellComm VI-PH
     // shutdownMotionEngineVI   // calls Model::shutdownMotionEngine VI-PH  shutdownNetworkInterfaceVI  //

--- a/src/LSST/state/IdleState.h
+++ b/src/LSST/state/IdleState.h
@@ -54,6 +54,11 @@ public:
     /// Do not stop motion or turn off power when entering this state.
     void enterState(State::Ptr const& oldName) override;
 
+    /// Turn the power for the indicated power subsystem on or off.
+    /// @see state::State::cmdPowerBase(control::PowerSystemType powerType, bool on)
+    /// VI setPowerVI // calls Model::setPowerVI(CommPowerControl, MotorPowerControl)
+    bool cmdPower(control::PowerSystemType powerType, bool on) override;
+
     // VI  goToInMotionVI // calls Model::changeStateVI(ReadyInMotion)
     // Handled by calling StateMap::changeState(StandbyState);
 
@@ -64,9 +69,6 @@ public:
     // VI-PH  loadScriptVI // calls Model::loadScriptVI(scriptFilename)
     // VI-PH  pauseScriptVI // calls Model::pauseScriptVI
     // VI-PH  resumeScriptVI // calls Model::resumeScriptVI
-
-    /// VI setPowerVI // calls Model::setPowerVI(CommPowerControl, MotorPowerControl)
-    bool cmdPower(control::PowerSystemType powerType, bool on) override;
 
     // VI-PH  shutdownCellCommVI // calls Model::shutdownCellComm VI-PH
     // shutdownMotionEngineVI   // calls Model::shutdownMotionEngine VI-PH  shutdownNetworkInterfaceVI  //

--- a/src/LSST/state/InMotionState.cpp
+++ b/src/LSST/state/InMotionState.cpp
@@ -38,9 +38,7 @@ InMotionState::Ptr InMotionState::create(StateMap& stateMap, Model* const model)
     return state;
 }
 
-void InMotionState::enterState(State::Ptr const& oldState) {
-    enterStateBase(oldState);
-}
+void InMotionState::enterState(State::Ptr const& oldState) { enterStateBase(oldState); }
 
 void InMotionState::goToIdleReadyVI() { throw util::Bug(ERR_LOC, "goToInMotion PLACEHOLDER"); }
 

--- a/src/LSST/state/InMotionState.cpp
+++ b/src/LSST/state/InMotionState.cpp
@@ -38,6 +38,10 @@ InMotionState::Ptr InMotionState::create(StateMap& stateMap, Model* const model)
     return state;
 }
 
+void InMotionState::enterState(State::Ptr const& oldState) {
+    enterStateBase(oldState);
+}
+
 void InMotionState::goToIdleReadyVI() { throw util::Bug(ERR_LOC, "goToInMotion PLACEHOLDER"); }
 
 void InMotionState::goToPauseVI() { throw util::Bug(ERR_LOC, "goToPauseVI PLACEHOLDER"); }

--- a/src/LSST/state/InMotionState.h
+++ b/src/LSST/state/InMotionState.h
@@ -48,6 +48,9 @@ public:
     InMotionState& operator=(InMotionState const&) = delete;
     virtual ~InMotionState() = default;
 
+    /// Do not stop motion or turn off power when entering this state.
+    void enterState(State::Ptr const& oldName) override;
+
     /// VI-PH  goToIdleReadyVI // calls Model::changeStateVI(ReadyIdle)
     void goToIdleReadyVI() override;
 

--- a/src/LSST/state/Model.cpp
+++ b/src/LSST/state/Model.cpp
@@ -20,14 +20,22 @@
  */
 
 // Class header
-#include "../state/Model.h"
+#include "state/Model.h"
 
+// third party headers
+#include <nlohmann/json.hpp>
+
+// project headers
+#include "control/ControlMain.h"
 #include "control/MotionEngine.h"
 #include "control/PowerSystem.h"
 #include "state/State.h"
+#include "system/ComControlServer.h"
+#include "system/Globals.h"
 #include "util/Log.h"
 
 using namespace std;
+using json = nlohmann::json;
 
 namespace LSST {
 namespace m2cellcpp {
@@ -38,6 +46,7 @@ Model::Model() {
     _powerSystem = control::PowerSystem::Ptr(new control::PowerSystem());
     _motionEngine = control::MotionEngine::getPtr();
     _fpgaCtrl = control::FpgaIo::getPtr();
+    _fpgaCtrl->registerPowerSys(_powerSystem);
 }
 
 state::State::Ptr Model::getCurrentState() {
@@ -55,6 +64,19 @@ bool Model::changeState(std::shared_ptr<state::State> const& newState) {
     return _stateMap.changeState(newState);
 }
 
+void Model::systemShutdown() {
+    VMUTEX_NOT_HELD(_mtx);
+    // Going to OFFLINESTATE should prevent anything from being turned
+    // back on during shutdown.
+    changeState(getState(State::StateEnum::OFFLINESTATE));
+    {
+        std::lock_guard<util::VMutex> lockg(_mtx);
+        _turnOffAll("shutdown");
+    }
+    auto ctMain = control::ControlMain::getPtr();
+    ctMain->stop();
+}
+
 bool Model::goToSafeMode(std::string const& note) {
     VMUTEX_NOT_HELD(_mtx);
     std::lock_guard<util::VMutex> lockg(_mtx);
@@ -63,6 +85,7 @@ bool Model::goToSafeMode(std::string const& note) {
 
 bool Model::_goToSafeMode(std::string const& note) {
     VMUTEX_HELD(_mtx);
+    _turnOffAll(note);
     return _stateMap.goToASafeState(State::STANDBYSTATE, note);
 }
 
@@ -81,21 +104,83 @@ bool Model::_turnOffAll(string const& note) {
     return true;
 }
 
-bool Model::_setPower(bool on) {
-    VMUTEX_HELD(_mtx);
-    if (_powerSystem == nullptr) {
-        LERROR("Model::", __func__, " _powerSystem is nullptr");
-        return false;
-    }
 
-    if (on) {
-        _powerSystem->getMotor().setPowerOn();
-        _powerSystem->getComm().setPowerOn();
-    } else {
-        _powerSystem->getMotor().setPowerOff(string(__func__));
-        _powerSystem->getComm().setPowerOff(string(__func__));
+void Model::reportPowerSystemStateChange(control::PowerSystemType systemType, control::PowerState targPowerState, control::PowerState actualPowerState) {
+    VMUTEX_NOT_HELD(_mtx);
+    LTRACE("Model::reportPowerSystemStateChange ", getPowerSystemTypeStr(systemType), " targ=", getPowerStateStr(targPowerState), " act=", getPowerStateStr(actualPowerState));
+    {
+        std::lock_guard<util::VMutex> lockg(_mtx);
+        // Is a state change required?
+        // If inOfflineState, stay in OfflineState (turning off all power if needed)
+        auto currentState = _stateMap.getCurrentState();;
+        auto currentStateId = currentState->getId();
+        auto comTargPower = _powerSystem->getComm().getTargPowerState();
+        auto motorTargPower = _powerSystem->getMotor().getTargPowerState();
+        auto comActPower = _powerSystem->getComm().getActualPowerState();
+        auto motorActPower = _powerSystem->getMotor().getActualPowerState();
+        LINFO("Model::reportPowerSystemStateChange com(targ=", comTargPower, " act=", comActPower,
+                ") motor(targ=", motorTargPower, " act=", motorActPower, ")");
+        switch (currentStateId) {
+        case State::STARTUPSTATE:
+            [[fallthrough]];
+        case State::OFFLINESTATE:
+        {
+            /// Power should always be OFF in these states.
+            if (comTargPower != control::PowerState::OFF || motorTargPower != control::PowerState::OFF) {
+                _turnOffAll("Model::reportPowerSystemStateChange state=" + currentState->getName());
+            }
+            break;
+        }
+
+        case State::IDLESTATE:
+            [[fallthrough]];
+        case State::INMOTIONSTATE:
+            [[fallthrough]];
+        case State::PAUSESTATE:
+        {
+            // Power should always be ON in these states, if not go to STANDBYSTATE.
+            if (comTargPower != control::PowerState::ON
+                    || comActPower != control::PowerState::ON
+                    || motorTargPower != control::PowerState::ON
+                    || motorActPower != control::PowerState::ON) {
+                _stateMap.changeState(State::STANDBYSTATE);
+            }
+            break;
+        }
+
+        case State::STANDBYSTATE:
+        {
+            // Power may be ON or OFF in this state.
+            // Normally, MOTOR power should only be on if COMM power is on, but that is tested elsewhere.
+            // If both COMM and MOTOR power are on, the state should change to IDLESTATE
+            if (comTargPower == control::PowerState::ON
+                    && comActPower == control::PowerState::ON
+                    && motorTargPower == control::PowerState::ON
+                    && motorActPower == control::PowerState::ON) {
+                LTRACE("Model::reportPowerSystemStateChange change to IDLESTATE");
+                _stateMap.changeState(State::IDLESTATE);
+            }
+            break;
+        }
+        }
+    } // No need to hold _mtx any longer.
+
+    // Make and broadcast the json message
+    auto comServ = system::ComControlServer::get().lock();
+    if (comServ != nullptr) {
+        json js;
+        js["id"] = "powerSystemState";
+        js["powerType"] = static_cast<int>(systemType);
+        js["state"] = static_cast<int>(actualPowerState);
+        bool targetOn = (targPowerState == control::PowerState::ON);
+        js["status"] = targetOn;
+        if (system::Globals::get().isSendUserInfo()) {
+            string infoStr = getPowerSystemTypeStr(systemType) + " is " + getPowerStateOldStr(actualPowerState) + " turning " + getPowerStateStr(targPowerState);
+            js["user_info"] = infoStr;
+        }
+        string msg = to_string(js);
+        comServ->asyncWriteToAllComConn(msg);
     }
-    return true;
 }
 
 void Model::ctrlSetup() {
@@ -186,6 +271,10 @@ void Model::ctrlStart() {
     // - _scriptEngine - Controller->startScriptEngine.vi - start the script engine - FUTURE-FAR
     // - _cellCtrlComm - Controller->startupCellCommunications
     // - Do not need to start - _faultMgr[no threads], _fpgaCtrl[started in constructor],
+
+    // Startup is finished at this point, advance to StandbyState.
+    auto newState = _stateMap.getStandbyState();
+    _stateMap.changeState(newState);
 }
 
 void Model::waitForCtrlReady() const {

--- a/src/LSST/state/Model.cpp
+++ b/src/LSST/state/Model.cpp
@@ -122,7 +122,6 @@ void Model::reportPowerSystemStateChange(control::PowerSystemType systemType,
         // Is a state change required?
         // If inOfflineState, stay in OfflineState (turning off all power if needed)
         auto currentState = _stateMap.getCurrentState();
-        ;
         auto currentStateId = currentState->getId();
         auto comTargPower = _powerSystem->getComm().getTargPowerState();
         auto motorTargPower = _powerSystem->getMotor().getTargPowerState();

--- a/src/LSST/state/Model.h
+++ b/src/LSST/state/Model.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 // Project headers
+#include "control/control_defs.h"
 #include "state/State.h"
 #include "state/StateMap.h"
 #include "util/VMutex.h"
@@ -57,6 +58,10 @@ public:
     /// Return a pointer to the `_powerSystem`.
     std::shared_ptr<control::PowerSystem> getPowerSystem() { return _powerSystem; }
 
+    /// Shutdown the entire system.
+    /// &&& doc
+    void systemShutdown();
+
     /// Read configuration files that haven't yet been read and use those
     /// values to setup various aspects of the system.
     void ctrlSetup();
@@ -78,7 +83,7 @@ public:
     /// Join threads started in `ctrlStart()`.
     void ctrlJoin();
 
-    /// Change the current state to `newState`, taking rquired actions.
+    /// Change the current state to `newState`, taking required actions.
     /// @return false in `newState` is invalid.
     bool changeState(std::shared_ptr<state::State> const& newState);
 
@@ -94,6 +99,17 @@ public:
     /// @param note - Description of reason for safe mode.
     /// @return true if the system was not already trying to reach.
     bool goToSafeMode(std::string const& note);
+
+    /// Return a pointer to the power system.
+    std::shared_ptr<control::PowerSystem> getPowerSystem() const;
+
+    /// This function allows PowerSubsytem instances to inform the model that their stat has changed.
+    /// The changes in the PowerSystem can result in changes being made to the overal system state in
+    /// `state::Model`.
+    /// @param systemType - the type of the power subsytem reporting a state change.
+    /// @param `targePowerState` - the new target state for the subsystem (should be ON of OFF).
+    /// @param `actualPowerState` - the current state for the subsystem.
+    void reportPowerSystemStateChange(control::PowerSystemType systemType, control::PowerState targPowerState, control::PowerState actualPowerState);
 
     /// Accessors
     // VI-PH readApplicationElementsVI  // can probably skip this one
@@ -190,11 +206,6 @@ private:
     /// Stop motion and turn off all power that can be turned off.
     bool _turnOffAll(std::string const& note);
 
-    /// Return true if power could be set, this affects both MOTOR and COMM power.
-    /// This does not mean the power is completely on or off, just that the
-    /// process has started.
-    bool _setPower(bool on);
-
     /// `_stateMap` contains all possible system states and the current system state.
     /// This member serves a similar purpose to the LabView `_commandFactory` and `_state`.
     StateMap _stateMap{this};
@@ -214,8 +225,9 @@ private:
 
     // _cellCommRef // systemElement VI-PH
     // _powerStatus // systemElement  _commPowerOn, _motorPowerOn VI-PH
-    std::shared_ptr<control::PowerSystem>
-            _powerSystem;  ///< The PowerSystem control instance, contains power states.
+
+    /// The PowerSystem control instance, contains power states.
+    std::shared_ptr<control::PowerSystem> _powerSystem;
 
     std::shared_ptr<control::FpgaIo> _fpgaCtrl;  ///< pointer to the global instance of FpgaIo.
 

--- a/src/LSST/state/Model.h
+++ b/src/LSST/state/Model.h
@@ -59,7 +59,8 @@ public:
     std::shared_ptr<control::PowerSystem> getPowerSystem() { return _powerSystem; }
 
     /// Shutdown the entire system.
-    /// &&& doc
+    /// This function will first turn off power and then attempt
+    /// to shutdown the rest of the system in an orderly manner.
     void systemShutdown();
 
     /// Read configuration files that haven't yet been read and use those
@@ -109,7 +110,8 @@ public:
     /// @param systemType - the type of the power subsytem reporting a state change.
     /// @param `targePowerState` - the new target state for the subsystem (should be ON of OFF).
     /// @param `actualPowerState` - the current state for the subsystem.
-    void reportPowerSystemStateChange(control::PowerSystemType systemType, control::PowerState targPowerState, control::PowerState actualPowerState);
+    void reportPowerSystemStateChange(control::PowerSystemType systemType, control::PowerState targPowerState,
+                                      control::PowerState actualPowerState);
 
     /// Accessors
     // VI-PH readApplicationElementsVI  // can probably skip this one

--- a/src/LSST/state/PauseState.cpp
+++ b/src/LSST/state/PauseState.cpp
@@ -40,6 +40,10 @@ PauseState::Ptr PauseState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
+void PauseState::enterState(State::Ptr const& oldState) {
+    enterStateBase(oldState);
+}
+
 void PauseState::goToIdleReadyVI() { throw util::Bug(ERR_LOC, "goToIdleReady PLACEHOLDER"); }
 
 void PauseState::goToInMotionVI() { throw util::Bug(ERR_LOC, "goToInMotion PLACEHOLDER"); }

--- a/src/LSST/state/PauseState.cpp
+++ b/src/LSST/state/PauseState.cpp
@@ -40,9 +40,7 @@ PauseState::Ptr PauseState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
-void PauseState::enterState(State::Ptr const& oldState) {
-    enterStateBase(oldState);
-}
+void PauseState::enterState(State::Ptr const& oldState) { enterStateBase(oldState); }
 
 void PauseState::goToIdleReadyVI() { throw util::Bug(ERR_LOC, "goToIdleReady PLACEHOLDER"); }
 

--- a/src/LSST/state/PauseState.h
+++ b/src/LSST/state/PauseState.h
@@ -48,6 +48,9 @@ public:
     PauseState& operator=(PauseState const&) = delete;
     virtual ~PauseState() = default;
 
+    /// Do not turn off power when entering this state.
+    void enterState(State::Ptr const& oldName) override;
+
     /// VI-PH  goToIdleReadyVI // calls Model::changeStateVI(ReadyIdle)
     void goToIdleReadyVI() override;
 

--- a/src/LSST/state/StandbyState.cpp
+++ b/src/LSST/state/StandbyState.cpp
@@ -41,9 +41,7 @@ StandbyState::Ptr StandbyState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
-void StandbyState::enterState(State::Ptr const& oldState) {
-    enterStateBase(oldState);
-}
+void StandbyState::enterState(State::Ptr const& oldState) { enterStateBase(oldState); }
 
 bool StandbyState::cmdPower(control::PowerSystemType powerType, bool on) {
     return cmdPowerBase(powerType, on);

--- a/src/LSST/state/StandbyState.cpp
+++ b/src/LSST/state/StandbyState.cpp
@@ -41,6 +41,14 @@ StandbyState::Ptr StandbyState::create(StateMap& stateMap, Model* const model) {
     return state;
 }
 
+void StandbyState::enterState(State::Ptr const& oldState) {
+    enterStateBase(oldState);
+}
+
+bool StandbyState::cmdPower(control::PowerSystemType powerType, bool on) {
+    return cmdPowerBase(powerType, on);
+}
+
 }  // namespace state
 }  // namespace m2cellcpp
 }  // namespace LSST

--- a/src/LSST/state/StandbyState.h
+++ b/src/LSST/state/StandbyState.h
@@ -58,7 +58,8 @@ public:
     /// Model::changeStateVI(ReadyIdle)
     void startVI();
 
-    /// &&& doc
+    /// Turn the power for the indicated power subsystem on or off.
+    /// @see state::State::cmdPowerBase(control::PowerSystemType powerType, bool on)
     bool cmdPower(control::PowerSystemType powerType, bool on) override;
 
 private:

--- a/src/LSST/state/StandbyState.h
+++ b/src/LSST/state/StandbyState.h
@@ -48,12 +48,18 @@ public:
     StandbyState& operator=(StandbyState const&) = delete;
     virtual ~StandbyState() = default;
 
+    /// Do not stop motion or turn off power when entering this state.
+    void enterState(State::Ptr const& oldName) override;
+
     /// VI-PH  exitVI // calls Model::changeStateVI(OfflineState)
     void exitVI();
 
     /// VI-PH  startVI // calls Model::startVI  then  Model::stopMotionVI  then
     /// Model::changeStateVI(ReadyIdle)
     void startVI();
+
+    /// &&& doc
+    bool cmdPower(control::PowerSystemType powerType, bool on) override;
 
 private:
     StandbyState(Model* const model) : State(STANDBYSTATE, model) {}

--- a/src/LSST/state/State.cpp
+++ b/src/LSST/state/State.cpp
@@ -82,7 +82,6 @@ void State::onExitState(State::Ptr const& newState) {
     exitState(newState);
 }
 
-
 bool State::cmdPowerBase(control::PowerSystemType powerType, bool on) {
     bool result = false;
     auto powerSys = modelPtr->getPowerSystem();
@@ -90,15 +89,15 @@ bool State::cmdPowerBase(control::PowerSystemType powerType, bool on) {
         return false;
     }
     switch (powerType) {
-    case control::MOTOR:
-        result = powerSys->powerMotor(on);
-        break;
-    case control::COMM:
-        result = powerSys->powerComm(on);
-        break;
-    default:
-        LERROR("State::cmdPowerBase unknown _powerType=", powerType);
-        return false;
+        case control::MOTOR:
+            result = powerSys->powerMotor(on);
+            break;
+        case control::COMM:
+            result = powerSys->powerComm(on);
+            break;
+        default:
+            LERROR("State::cmdPowerBase unknown _powerType=", powerType);
+            return false;
     }
     return result;
 }

--- a/src/LSST/state/State.cpp
+++ b/src/LSST/state/State.cpp
@@ -23,6 +23,7 @@
 #include "state/State.h"
 
 // Project headers
+#include "control/PowerSystem.h"
 #include "state/Model.h"
 #include "state/StateMap.h"
 #include "util/Bug.h"
@@ -63,8 +64,7 @@ void State::errorWrongStateMsg(std::string const& action) {
 }
 
 void State::enterState(State::Ptr const& oldState) {
-    string msg("State::enterState " + getName());
-    LINFO(msg);
+    string msg = enterStateBase(oldState);
     if (modelPtr == nullptr) {
         LERROR("State::enterState ignoring due to unit test.");
         return;
@@ -80,6 +80,37 @@ void State::onEnterState(State::Ptr const& oldState) {
 void State::onExitState(State::Ptr const& newState) {
     LINFO("Leaving state=", getName(), " to go to newState=", newState->getName());
     exitState(newState);
+}
+
+
+bool State::cmdPowerBase(control::PowerSystemType powerType, bool on) {
+    bool result = false;
+    auto powerSys = modelPtr->getPowerSystem();
+    if (powerSys == nullptr) {
+        return false;
+    }
+    switch (powerType) {
+    case control::MOTOR:
+        result = powerSys->powerMotor(on);
+        break;
+    case control::COMM:
+        result = powerSys->powerComm(on);
+        break;
+    default:
+        LERROR("State::cmdPowerBase unknown _powerType=", powerType);
+        return false;
+    }
+    return result;
+}
+
+string State::enterStateBase(State::Ptr const& oldState) {
+    string oldStateStr;
+    if (oldState != nullptr) {
+        oldStateStr = oldState->getName();
+    }
+    string msg("State::enterStateBase to " + getName() + " from " + oldStateStr);
+    LINFO(msg);
+    return msg;
 }
 
 }  // namespace state

--- a/src/LSST/state/State.h
+++ b/src/LSST/state/State.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 // Project headers
+#include "control/control_defs.h"
 #include "util/Bug.h"
 
 namespace LSST {
@@ -137,10 +138,11 @@ public:
 
     /// Return true if power could be set to 'on'.
     /// VI-PH  setPowerVI;
-    virtual bool setPower(bool on) {
-        errorWrongStateMsg("setPower");
+    virtual bool cmdPower(control::PowerSystemType powerType, bool on) {
+        errorWrongStateMsg("cmdPower");
         return false;
     }
+
     // VI-PH  setSlewingStateVI; // ??? if case with no effect
     // VI-PH  shutdownCellCommVI; // ??? if case with no effect
     // VI-PH  shutdownLoggerVI; // Nada
@@ -164,6 +166,13 @@ public:
 protected:
     /// Constant pointer to the model, which can be nullptr in unit tests.
     Model* const modelPtr;
+
+
+    /// &&& doc - the rules for turning power on and off are icky, need separate on off functions in different states.
+    bool cmdPowerBase(control::PowerSystemType powerType, bool on);
+
+    /// &&& doc
+    std::string  enterStateBase(State::Ptr const& oldName);
 
 private:
     StateEnum const _stateId;  ///< The type of this state.

--- a/src/LSST/state/State.h
+++ b/src/LSST/state/State.h
@@ -167,12 +167,17 @@ protected:
     /// Constant pointer to the model, which can be nullptr in unit tests.
     Model* const modelPtr;
 
-
-    /// &&& doc - the rules for turning power on and off are icky, need separate on off functions in different states.
+    /// This function is called by child classes to turn power on or off for
+    /// `PowerSubsystem` instances.
+    /// Turn the power for the indicated power subsystem on or off.
+    /// Changes to the power states can result in system `State` changes.
+    /// @param powerType - subsystem to be turned on or off (MOTOR or COMM).
+    /// @param on - Turn power on if true, or off if false.
     bool cmdPowerBase(control::PowerSystemType powerType, bool on);
 
-    /// &&& doc
-    std::string  enterStateBase(State::Ptr const& oldName);
+    /// This function contains default actions to do when entering a new state,
+    /// primarily associated with logging.
+    std::string enterStateBase(State::Ptr const& oldName);
 
 private:
     StateEnum const _stateId;  ///< The type of this state.

--- a/src/LSST/state/StateMap.cpp
+++ b/src/LSST/state/StateMap.cpp
@@ -94,6 +94,7 @@ bool StateMap::_changeState(State::Ptr const& newState) {
         LWARN("StateMap cannot change state to nullptr");
         return false;
     }
+    LDEBUG("StateMap::_changeState trying to change to ", newState->getName());
 
     // The new state should have been verified as being in the map.
     auto oldState = _currentState;

--- a/src/LSST/system/ComClient.cpp
+++ b/src/LSST/system/ComClient.cpp
@@ -120,14 +120,14 @@ int ComClient::readWelcomeMsg() {
     return count;
 }
 
-tuple<nlohmann::json, nlohmann::json> ComClient::cmdSendRecv(string const& jStr, uint seqId, string const& note) {
+tuple<nlohmann::json, nlohmann::json> ComClient::cmdSendRecv(string const& jStr, uint seqId,
+                                                             string const& note) {
     writeCommand(jStr);
     LDEBUG(note, "cmdSendRecv:wrote jStr=", jStr);
     auto ackJ = cmdRecvSeqId(seqId, "cmdSendRecv");
     auto finJ = cmdRecvSeqId(seqId, "cmdSendRecv");
     return {ackJ, finJ};
 }
-
 
 nlohmann::json ComClient::cmdRecvSeqId(uint seqId, string const& note) {
     bool found = false;
@@ -169,7 +169,6 @@ nlohmann::json ComClient::cmdRecvId(string const& targetId, string const& note) 
     return js;
 }
 
-
 JsonMsgMap::JsonDeque ComClient::recvDequeForId(string const& key, string const& note) {
     // Check if it is in the map
     JsonMsgMap::JsonDeque jDeque = _jMsgMap.getDequeFor(key);
@@ -182,12 +181,9 @@ JsonMsgMap::JsonDeque ComClient::recvDequeForId(string const& key, string const&
     return jDeque;
 }
 
-
-
 void JsonMsgMap::insert(string const& key, nlohmann::json const& js) {
     LTRACE("JsonMsgMap::insert js", to_string(js));
     (*_msgMap)[key].push_back(js);
-
 }
 
 JsonMsgMap::JsonDeque JsonMsgMap::getDequeFor(std::string const& key) {
@@ -201,7 +197,6 @@ JsonMsgMap::JsonDeque JsonMsgMap::getDequeFor(std::string const& key) {
     jd.clear();
     return jDeque;
 }
-
 
 }  // namespace system
 }  // namespace m2cellcpp

--- a/src/LSST/system/ComClient.cpp
+++ b/src/LSST/system/ComClient.cpp
@@ -90,10 +90,11 @@ string ComClient::readCommand() {
         throw boost::system::system_error(ec);
     }
     using boost::asio::buffers_begin;
-    // Copy the contents of _readStream upto, but not including the delimiter.
+    // Copy the contents of _readStream up to, but not including the delimiter.
     string outStr(buffers_begin(_readStream.data()), buffers_begin(_readStream.data()) + xfer - delimSz);
     // Remove the entire message, including delimiter, from _readStream so the next message is clean.
     _readStream.consume(xfer);
+    LTRACE("ComClient::readCommand() ", outStr);
     return outStr;
 }
 
@@ -118,6 +119,89 @@ int ComClient::readWelcomeMsg() {
     }
     return count;
 }
+
+tuple<nlohmann::json, nlohmann::json> ComClient::cmdSendRecv(string const& jStr, uint seqId, string const& note) {
+    writeCommand(jStr);
+    LDEBUG(note, "cmdSendRecv:wrote jStr=", jStr);
+    auto ackJ = cmdRecvSeqId(seqId, "cmdSendRecv");
+    auto finJ = cmdRecvSeqId(seqId, "cmdSendRecv");
+    return {ackJ, finJ};
+}
+
+
+nlohmann::json ComClient::cmdRecvSeqId(uint seqId, string const& note) {
+    bool found = false;
+    nlohmann::json js;
+    while (!found) {
+        LDEBUG(note, "cmdRecvId waiting for ", seqId);
+        string inStr = readCommand();
+        LDEBUG(note, "cmdRecvId:read ", seqId, " ", inStr);
+        js = nlohmann::json::parse(inStr);
+        auto iter = js.find("sequence_id");
+        if (iter != js.end() && *iter == seqId) {
+            found = true;
+            LDEBUG(note, "cmdSendRecv:read ", seqId, "=", js);
+        } else {
+            LDEBUG(note, "cmdSendRecv:read not ", seqId, " storing ", js);
+            _jMsgMap.insert(js["id"], js);
+        }
+    }
+    return js;
+}
+
+nlohmann::json ComClient::cmdRecvId(string const& targetId, string const& note) {
+    bool found = false;
+    nlohmann::json js;
+    while (!found) {
+        LDEBUG(note, "cmdRecvId waiting for ", targetId);
+        string inStr = readCommand();
+        LDEBUG(note, "cmdRecvId:read ", targetId, " ", inStr);
+        js = nlohmann::json::parse(inStr);
+        auto& jsId = js["id"];
+        if (jsId == targetId) {
+            found = true;
+            LDEBUG(note, "cmdSendRecv:read ", targetId, "=", js);
+        } else {
+            LDEBUG(note, "cmdSendRecv:read not ", targetId, " storing ", js);
+            _jMsgMap.insert(jsId, js);
+        }
+    }
+    return js;
+}
+
+
+JsonMsgMap::JsonDeque ComClient::recvDequeForId(string const& key, string const& note) {
+    // Check if it is in the map
+    JsonMsgMap::JsonDeque jDeque = _jMsgMap.getDequeFor(key);
+    if (!jDeque.empty()) {
+        LTRACE("ComClient::recvDequeForId found ", key, " in map. ", note);
+        return jDeque;
+    }
+    auto js = cmdRecvId(key, note);
+    jDeque.push_back(js);
+    return jDeque;
+}
+
+
+
+void JsonMsgMap::insert(string const& key, nlohmann::json const& js) {
+    LTRACE("JsonMsgMap::insert js", to_string(js));
+    (*_msgMap)[key].push_back(js);
+
+}
+
+JsonMsgMap::JsonDeque JsonMsgMap::getDequeFor(std::string const& key) {
+    JsonDeque jDeque;
+    auto iter = _msgMap->find(key);
+    if (iter == _msgMap->end()) {
+        return jDeque;
+    }
+    JsonDeque& jd = iter->second;
+    jDeque = move(jd);
+    jd.clear();
+    return jDeque;
+}
+
 
 }  // namespace system
 }  // namespace m2cellcpp

--- a/src/LSST/system/ComClient.h
+++ b/src/LSST/system/ComClient.h
@@ -37,7 +37,22 @@ namespace LSST {
 namespace m2cellcpp {
 namespace system {
 
-/// &&& doc
+/// This class is used to store json messages from the server
+/// that are not associated with the current command the `Client`
+/// is running. The `Client` class is only meant for simple
+/// testing, and generally only runs one command at a time in
+/// a single thread. Messages not required for the current client
+/// request are stored here so they can be examined later.
+///
+/// The key for _msgMap is the "id" from the json message.
+/// The json messages for the same "id" are stored in a deque
+/// with the oldest being at the front. It is assumed that
+/// only the newest will be relevant in most (but not all)
+/// cases.
+///
+/// Most actions involving getting from the map are destructive
+/// with the expectation that old entries can confuse tests
+/// and the map should be cleared before certain tests.
 class JsonMsgMap {
 public:
     typedef std::deque<nlohmann::json> JsonDeque;
@@ -47,10 +62,10 @@ public:
     JsonMsgMap(JsonMsgMap const&) = default;
     ~JsonMsgMap() = default;
 
-    /// &&& doc
+    /// Insert `js` into `_msgMap` where `key` is the "id" from `js`.
     void insert(std::string const& key, nlohmann::json const& js);
 
-    /// &&& doc Return the JsonDeque for `key` using move.
+    /// Return the JsonDeque for `key` using move.
     JsonDeque getDequeFor(std::string const& key);
 
     /// Returns the current `_msgMap` and replaces `_msgMap` with a new empty one.
@@ -65,7 +80,6 @@ private:
     /// made by the client.
     std::shared_ptr<JdMap> _msgMap{new JdMap()};
 };
-
 
 /// A class used for testing ComServer by making a connection to the server
 /// and running commands.
@@ -95,16 +109,40 @@ public:
     ///  A negative value indicates failure.
     int readWelcomeMsg();
 
-    /// &&& doc
-    std::tuple<nlohmann::json, nlohmann::json> cmdSendRecv(std::string const& jStr, uint seqId, std::string const& note);
+    /// Send a command to the server and receive the "ack", "success" or "fail"
+    /// messages.
+    /// @param `jStr` a string containing the json formatted command to send to the server.
+    /// @param `seqId` the numeric sequence ID associated with this command.
+    /// @param `note` a string describing what is responsible for sending the command.
+    /// @return ack - the resulting "ack" or "noack" message associated with `seqId`.
+    /// @return fin - the resulting "success" or "fail" message associated with `seqId`.
+    std::tuple<nlohmann::json, nlohmann::json> cmdSendRecv(std::string const& jStr, uint seqId,
+                                                           std::string const& note);
 
-    /// &&& doc
+    /// Receive commands from the server until "id" == `targetId` is found.
+    /// This function will continue to read commands until `targetId` is
+    /// read. Other messages received will be stored in `_jMsgMap`.
+    /// @param targetId the "id" of the command that is needed.
+    /// @param `note` a string describing what wants the message.
+    /// @return the json message where "id" == `targetId`.
     nlohmann::json cmdRecvId(std::string const& targetId, std::string const& note);
 
-    /// &&& doc
+    /// Receive commands from the server until "id" == `targetId` is found.
+    /// This function will continue to read commands until `targetId` is
+    /// read. Other messages received will be stored in `_jMsgMap`.
+    /// @param seqId the "sequence_id" of the command that is needed.
+    /// @param `note` a string describing what wants the message.
+    /// @return the json message where "sequence_id" == `seqId`.
     nlohmann::json cmdRecvSeqId(uint seqId, std::string const& note);
 
-    /// &&& doc
+    /// Return the entire deque associated with `key` from `_jMsgMap`,
+    /// using a destructive move.
+    /// The method first checks `_jMsgMap` for the `key`. If it isn't found,
+    /// it then reads commands until it sees "id" == `key` and then returns
+    /// what it received inserted into the deque.
+    /// @param key the "id" of the message/deque that is needed.
+    /// @param `note` a string describing what wants the message/deque.
+    /// @return the deque where "id" == `key`.
     JsonMsgMap::JsonDeque recvDequeForId(std::string const& key, std::string const& note);
 
     /// Close the connection.
@@ -122,7 +160,8 @@ private:
     boost::asio::streambuf _readStream;
     std::mutex _readStreamMtx;  ///< Protects `_readStream`
 
-    /// &&& doc
+    /// A map where the key is the "id" of the json message and the value is
+    /// a deque of json messages received with that "id".
     JsonMsgMap _jMsgMap;
 };
 

--- a/src/LSST/system/ComConnection.cpp
+++ b/src/LSST/system/ComConnection.cpp
@@ -89,9 +89,10 @@ void ComConnection::_syncWrite(string const& inMsg) {
 }
 
 void ComConnection::beginProtocol() {
+    LTRACE("ComConnection::beginProtocol()");
     _connectionActive = true;
-    Globals::get().setTcpIpConnected(
-            true);  // This seems a bit early to set this, but it's what the gui expects.
+    // This seems a bit early to set this, but it's what the gui expects.
+    Globals::get().setTcpIpConnected(true);
     _sendWelcomeMsg();
     _receiveCommand();
 }

--- a/src/LSST/system/ComConnection.h
+++ b/src/LSST/system/ComConnection.h
@@ -42,6 +42,8 @@ class ComServer;
 /// io_context pointer definition.
 typedef std::shared_ptr<boost::asio::io_context> IoContextPtr;
 
+/// asio work guard definition to keep io_context run() from exiting early.
+
 /// This class is used to handle commands and responses over a connection
 /// until that connection is terminated.
 ///

--- a/src/LSST/system/ComControl.cpp
+++ b/src/LSST/system/ComControl.cpp
@@ -53,6 +53,8 @@ void ComControl::setupNormalFactory(control::NetCommandFactory::Ptr const& cmdFa
     cmdFactory->addNetCommand(control::NCmdNoAck::createFactoryVersion());
     cmdFactory->addNetCommand(control::NCmdEcho::createFactoryVersion());
     cmdFactory->addNetCommand(control::NCmdSwitchCommandSource::createFactoryVersion());
+    cmdFactory->addNetCommand(control::NCmdPower::createFactoryVersion());
+    cmdFactory->addNetCommand(control::NCmdSystemShutdown::createFactoryVersion());
 }
 
 std::tuple<std::string, util::Command::Ptr> ComControl::interpretCommand(std::string const& commandStr) {

--- a/src/LSST/system/ComServer.cpp
+++ b/src/LSST/system/ComServer.cpp
@@ -84,10 +84,12 @@ void ComServer::run() {
     int threadCount = Config::get().getControlServerThreads();
     vector<shared_ptr<thread>> threads(threadCount);
     for (auto&& ptr : threads) {
-        ptr = shared_ptr<thread>(new thread([&]() { _ioContext->run(); }));
+        ptr = shared_ptr<thread>(new thread([&]() {
+            _ioContext->run();
+        }));
     }
     _state = RUNNING;
-    LDEBUG("ComServer::run() RUNNING");
+    LDEBUG("ComServer::run() RUNNING threads=", threadCount);
 
     // Wait for all threads in the pool to exit.
     for (auto&& ptr : threads) {
@@ -108,6 +110,7 @@ void ComServer::_beginAccept() {
 }
 
 void ComServer::_handleAccept(ComConnection::Ptr const& connection, boost::system::error_code const& ec) {
+    LINFO("ComServer::_handleAccept");
     if (_state == STOPPED || _shutdown) {
         return;
     }
@@ -148,6 +151,7 @@ void ComServer::shutdown() {
             conn->shutdown();
         }
     }
+    LINFO("ComServer::shutdown end");
 }
 
 void ComServer::eraseConnection(uint64_t connId) {

--- a/src/LSST/system/ComServer.cpp
+++ b/src/LSST/system/ComServer.cpp
@@ -84,9 +84,7 @@ void ComServer::run() {
     int threadCount = Config::get().getControlServerThreads();
     vector<shared_ptr<thread>> threads(threadCount);
     for (auto&& ptr : threads) {
-        ptr = shared_ptr<thread>(new thread([&]() {
-            _ioContext->run();
-        }));
+        ptr = shared_ptr<thread>(new thread([&]() { _ioContext->run(); }));
     }
     _state = RUNNING;
     LDEBUG("ComServer::run() RUNNING threads=", threadCount);

--- a/src/LSST/system/ComServer.h
+++ b/src/LSST/system/ComServer.h
@@ -94,6 +94,7 @@ public:
     /// Async write the `msg` to all existing ComConnections for this ComServer.
     void asyncWriteToAllComConn(std::string const& msg);
 
+
 protected:
     /// Protected constructor to force use of create().
     ComServer(IoContextPtr const& ioContext, int port);
@@ -105,8 +106,9 @@ private:
     /// Handle a connection request.
     void _handleAccept(ComConnection::Ptr const& connection, boost::system::error_code const& ec);
 
+
+    IoContextPtr _ioContext;  ///< Pointer to the asio io_context
     std::atomic<State> _state{CREATED};  ///< Current state of the machine.
-    IoContextPtr _ioContext;             ///< Pointer to the asio io_context
     int _port;
     boost::asio::ip::tcp::acceptor _acceptor;
 

--- a/src/LSST/system/ComServer.h
+++ b/src/LSST/system/ComServer.h
@@ -63,10 +63,6 @@ public:
     /// Run the server, this is a blocking opperation.
     void run();
 
-    /// Cause the server to stop responding to client requests.
-    /// This also shutsdown all connections using this server.
-    void shutdown();
-
     /// Remove 'connId' from the set of ComConnections.
     void eraseConnection(uint64_t connId);
 
@@ -94,6 +90,14 @@ public:
     /// Async write the `msg` to all existing ComConnections for this ComServer.
     void asyncWriteToAllComConn(std::string const& msg);
 
+    /// Cause the server to stop responding to client requests.
+    /// This also shutsdown all connections using this server.
+    void shutdown();
+
+    /// Destroy all communications channels associated with this server, including
+    /// `_ioContext`. This will essentially stop anything using `_ioContext`.
+    void destroy();
+
 protected:
     /// Protected constructor to force use of create().
     ComServer(IoContextPtr const& ioContext, int port);
@@ -111,6 +115,8 @@ private:
     boost::asio::ip::tcp::acceptor _acceptor;
 
     std::atomic<bool> _shutdown{false};  ///< set to true the first time shutdown is called.
+
+    std::atomic<bool> _destroyCalled{false};  ///< set to true the first time destroy is called.
 
     /// A map of all current connections made by this server.
     std::map<uint64_t, std::weak_ptr<ComConnection>> _connections;

--- a/src/LSST/system/ComServer.h
+++ b/src/LSST/system/ComServer.h
@@ -94,7 +94,6 @@ public:
     /// Async write the `msg` to all existing ComConnections for this ComServer.
     void asyncWriteToAllComConn(std::string const& msg);
 
-
 protected:
     /// Protected constructor to force use of create().
     ComServer(IoContextPtr const& ioContext, int port);
@@ -106,8 +105,7 @@ private:
     /// Handle a connection request.
     void _handleAccept(ComConnection::Ptr const& connection, boost::system::error_code const& ec);
 
-
-    IoContextPtr _ioContext;  ///< Pointer to the asio io_context
+    IoContextPtr _ioContext;             ///< Pointer to the asio io_context
     std::atomic<State> _state{CREATED};  ///< Current state of the machine.
     int _port;
     boost::asio::ip::tcp::acceptor _acceptor;

--- a/src/LSST/system/Globals.h
+++ b/src/LSST/system/Globals.h
@@ -130,6 +130,9 @@ public:
         return true;
     }
 
+    /// Return true if "user_info" elements are being sent to clients in json messages.
+    bool isSendUserInfo() const { return true; }
+
     /// Reset the global Ptr to Globals. PLACEHOLDER
     /// This should only be called at termination or unit testing.
     void reset();

--- a/tests/test_Com.cpp
+++ b/tests/test_Com.cpp
@@ -35,6 +35,7 @@
 #include "control/Context.h"
 #include "control/FpgaIo.h"
 #include "control/MotionEngine.h"
+#include "control/PowerSystem.h"
 #include "faultmgr/FaultMgr.h"
 #include "simulator/SimCore.h"
 #include "system/Config.h"
@@ -58,6 +59,12 @@ TEST_CASE("Test Com echo", "[Com]") {
     control::FpgaIo::setup(simCore);
     control::MotionEngine::setup();
     control::Context::setup();
+
+    // Power system and FpgaIo timeouts are not useful in this, turn them off.
+    control::Context::Ptr context = control::Context::get();
+    context->model.getPowerSystem()->stopTimeoutLoop();
+    control::FpgaIo::getPtr()->stopLoop();
+    control::MotionEngine::getPtr()->engineStop();
 
     REQUIRE(ComServer::prettyState(ComServer::CREATED) == "CREATED");
     REQUIRE(ComServer::prettyState(ComServer::RUNNING) == "RUNNING");

--- a/tests/test_ComControl.cpp
+++ b/tests/test_ComControl.cpp
@@ -42,7 +42,6 @@ using namespace std;
 using namespace LSST::m2cellcpp::system;
 using namespace LSST::m2cellcpp;
 
-
 TEST_CASE("Test ComControl", "[ComControl]") {
     util::Log::getLog().useEnvironmentLogLvl();
     string cfgPath = Config::getEnvironmentCfgPath("../configs");

--- a/tests/test_PowerSystem.cpp
+++ b/tests/test_PowerSystem.cpp
@@ -86,8 +86,6 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
     // At this point, MotionCtrl and FpgaCtrl should be configured. Start the control loops
     context->model.ctrlStart();
 
-
-
     while (simCore->getIterations() < 1) {
         this_thread::sleep_for(0.1s);
     }
@@ -119,7 +117,6 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(motorSubSys.getTargPowerState() == PowerState::OFF);
         simCore->waitForUpdate(telemWait);
         REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
-
 
         // Try to turn power on with any network connections
         LDEBUG("Turn motor power on, expected failure due to no network connections");
@@ -207,8 +204,6 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.commVoltage < voltageOffLevel);  // _voltageOffLevel
         REQUIRE(commSubSys.getActualPowerState() == PowerState::OFF);
-
-
 
         // comm,  turn power on as motor power tests require comm power on.
         LDEBUG("Turn comm power on so motor breakers can be tested");

--- a/tests/test_PowerSystem.cpp
+++ b/tests/test_PowerSystem.cpp
@@ -83,6 +83,11 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
     control::Context::Ptr context = control::Context::get();
     context->model.ctrlSetup();
 
+    // At this point, MotionCtrl and FpgaCtrl should be configured. Start the control loops
+    context->model.ctrlStart();
+
+
+
     while (simCore->getIterations() < 1) {
         this_thread::sleep_for(0.1s);
     }
@@ -91,6 +96,9 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         PowerSystem::Ptr powerSys = control::Context::get()->model.getPowerSystem();
         PowerSubsystem& motorSubSys = powerSys->getMotor();
         PowerSubsystem& commSubSys = powerSys->getComm();
+
+        // FUTURE: TODO: put this item into the configuration (or where does it really belong?)
+        powerSys->writeCrioInterlockEnable(true);
 
         REQUIRE(motorSubSys.getSystemType() == MOTOR);
         REQUIRE(commSubSys.getSystemType() == COMM);
@@ -108,15 +116,10 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getTargPowerState() == PowerSubsystem::OFF);
+        REQUIRE(motorSubSys.getTargPowerState() == PowerState::OFF);
         simCore->waitForUpdate(telemWait);
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::UNKNOWN);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
 
-        // Register the PowerSystem with FpgaIo so that it gets updates.
-        FpgaIo::get().registerPowerSys(powerSys);
-        powerSys->writeCrioInterlockEnable(true);
-        simCore->waitForUpdate(telemWait);
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
 
         // Try to turn power on with any network connections
         LDEBUG("Turn motor power on, expected failure due to no network connections");
@@ -129,46 +132,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         // power can be turned on.
         faultmgr::FaultMgr::get().reportComConnectionCount(1);
 
-        // turn power on
-        LDEBUG("Turn motor power on!!!");
-        motorSubSys.setPowerOn();
-        simCore->waitForUpdate(simWait);
-        sInfo = simCore->getSysInfo();
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
-
-        // verify power on
-        simCore->waitForUpdate(telemWait);        // wait for telemetry count
-        this_thread::sleep_for(voltageRiseWait);  // Need to wait for voltage rise and phases.
-        sInfo = simCore->getSysInfo();
-        LDEBUG("Verify motor power on!!!");
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
-        REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);
-        LDEBUG("Test motor power on!!!");
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::ON);
-
-        // turn power off
-        motorSubSys.setPowerOff("test motor power off");
-        simCore->waitForUpdate(5);
-        sInfo = simCore->getSysInfo();
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
-
-        // verify power off
-        simCore->waitForUpdate(simWaitLong);  // need to wait for voltage fall
-        sInfo = simCore->getSysInfo();
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
-        REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
-
-        // comm
-        // turn power on
+        // comm,  turn power on
         LDEBUG("Turn comm power on!!!");
         commSubSys.setPowerOn();
         simCore->waitForUpdate(simWait);
@@ -178,16 +142,55 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
 
-        // verify power on
+        // comm, verify power on
         simCore->waitForUpdate(telemWait);        // wait for telemetry count
         this_thread::sleep_for(voltageRiseWait);  // Need to wait for voltage rise and phases.
         sInfo = simCore->getSysInfo();
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
         REQUIRE(sInfo.commVoltage > approxMinVoltageFault);  // approximate _minVoltageFault
-        REQUIRE(commSubSys.getActualPowerState() == PowerSubsystem::ON);
+        REQUIRE(commSubSys.getActualPowerState() == PowerState::ON);
 
-        // turn power off
+        // motor, turn power on
+        // motor power can only be turned on if comm power is already on.
+        LDEBUG("Turn motor power on!!!");
+        motorSubSys.setPowerOn();
+        simCore->waitForUpdate(simWait);
+        sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
+
+        // motor, verify power on
+        simCore->waitForUpdate(telemWait);        // wait for telemetry count
+        this_thread::sleep_for(voltageRiseWait);  // Need to wait for voltage rise and phases.
+        sInfo = simCore->getSysInfo();
+        LDEBUG("Verify motor power on!!!");
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
+        REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);
+        LDEBUG("Test motor power on!!!");
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::ON);
+
+        // motor, turn power off
+        motorSubSys.setPowerOff("test motor power off");
+        simCore->waitForUpdate(5);
+        sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
+
+        // verify power off
+        simCore->waitForUpdate(simWaitLong);  // need to wait for voltage fall
+        sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
+        REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
+
+        // comm, turn power off
         commSubSys.setPowerOff("test comm power off");
         simCore->waitForUpdate(simWait);
         sInfo = simCore->getSysInfo();
@@ -195,7 +198,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
-        REQUIRE(commSubSys.getTargPowerState() == PowerSubsystem::OFF);
+        REQUIRE(commSubSys.getTargPowerState() == PowerState::OFF);
 
         // verify power off
         simCore->waitForUpdate(simWaitLong);  // need to wait for voltage fall
@@ -203,7 +206,28 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.commVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(commSubSys.getActualPowerState() == PowerSubsystem::OFF);
+        REQUIRE(commSubSys.getActualPowerState() == PowerState::OFF);
+
+
+
+        // comm,  turn power on as motor power tests require comm power on.
+        LDEBUG("Turn comm power on so motor breakers can be tested");
+        commSubSys.setPowerOn();
+        simCore->waitForUpdate(simWait);
+        sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
+
+        // comm, verify power on
+        simCore->waitForUpdate(telemWait);        // wait for telemetry count
+        this_thread::sleep_for(voltageRiseWait);  // Need to wait for voltage rise and phases.
+        sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
+        REQUIRE(sInfo.commVoltage > approxMinVoltageFault);  // approximate _minVoltageFault
+        REQUIRE(commSubSys.getActualPowerState() == PowerState::ON);
 
         // Test breaker reset
         // turn power on
@@ -220,7 +244,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::ON);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::ON);
 
         // Trip one breaker, power should remain on
         LINFO("Trip J2_W10_1_MTR_PWR_BRKR_OK=", control::InputPortBits::J2_W10_1_MTR_PWR_BRKR_OK);
@@ -233,7 +257,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);  // approximate _minVoltageFault
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::ON);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::ON);
         // FUTURE: DM-40909 check for FaultMgr warning
 
         // Trip a second breaker, power should go off
@@ -246,7 +270,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
 
         // Try to turn on, this should result in reset logic being used
         LDEBUG("Turning on for RESET test");
@@ -271,7 +295,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);  // approximate _minVoltageFault
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::ON);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::ON);
 
         // verify tripped breaker bit are back to ok
         REQUIRE(sInfo.inputPort.getBitAtPos(control::InputPortBits::J2_W10_3_MTR_PWR_BRKR_OK) == true);
@@ -288,17 +312,19 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
 
         /// Test for power off on over voltage.
         faultmgr::FaultMgr::get().reportComConnectionCount(1);  // need at least 1 TCP/IP
         LDEBUG("Turn power on for over voltage test.");
+        commSubSys.setPowerOn();
+        simCore->waitForUpdate(simWait);
         motorSubSys.setPowerOn();
         simCore->waitForUpdate(simWait);
         sInfo = simCore->getSysInfo();
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
-        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::ILC_COMM_POWER_ON) != 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_COMM_BREAKERS) != 0);
 
         // verify power on
@@ -309,7 +335,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage > approxMinVoltageFault);
         LDEBUG("Test motor power on");
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::ON);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::ON);
 
         // Let motor power run high
         LDEBUG("Motor voltage too high test");
@@ -326,7 +352,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
 
         // Reset fault
         simCore->getMotorSub()->forceOverVoltage(false);
@@ -350,7 +376,7 @@ TEST_CASE("Test PowerSystem", "[PowerSystem]") {
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::MOTOR_POWER_ON) == 0);
         REQUIRE(sInfo.outputPort.getBitAtPos(OutputPortBits::RESET_MOTOR_BREAKERS) != 0);
         REQUIRE(sInfo.motorVoltage < voltageOffLevel);  // _voltageOffLevel
-        REQUIRE(motorSubSys.getActualPowerState() == PowerSubsystem::OFF);
+        REQUIRE(motorSubSys.getActualPowerState() == PowerState::OFF);
 
         // Reset fault
         simCore->getMotorSub()->forceOverCurrent(false);

--- a/tests/test_startup_shutdown.cpp
+++ b/tests/test_startup_shutdown.cpp
@@ -34,31 +34,344 @@
 #include "control/ControlMain.h"
 #include "control/FpgaIo.h"
 #include "control/MotionEngine.h"
+#include "control/PowerSystem.h"
 #include "simulator/SimCore.h"
+#include "state/State.h"
+#include "system/ComClient.h"
+#include "system/ComControlServer.h"
 #include "system/Config.h"
 #include "util/Bug.h"
 #include "util/Log.h"
 
 using namespace std;
-using namespace LSST::m2cellcpp::control;
-using namespace LSST::m2cellcpp::state;
+using namespace LSST::m2cellcpp;
+
+/// Wait up to 5 seconds for `subsystem` to reach `targetState`, return true if that happens within the time limit.
+bool waitForPowerState(control::PowerState targetState, control::PowerSubsystem& subsystem, string const& note) {
+    auto waitStart = util::CLOCK::now();
+    bool success = false;
+    while (!success) {
+        auto aPowerState = subsystem.getActualPowerState();
+        auto volts = subsystem.getVoltage();
+        LDEBUG(note, " power=", control::getPowerStateStr(aPowerState), " volt=", volts);
+        success = targetState == aPowerState;
+        string powMsg(note + " power=" + control::getPowerStateStr(aPowerState) + " volt=" + to_string(volts) + " success=" + to_string(success));
+        LDEBUG(powMsg);
+        if (!success) {
+            auto waitTimePassed = util::CLOCK::now() - waitStart;
+            if (waitTimePassed > 5s) {
+                LERROR("waitForPowerState timedOut ", powMsg);
+                break;
+            }
+            this_thread::sleep_for(0.1s);
+        }
+    }
+    return success;
+}
+
+// Wait up to 1 second for the model state to reach `targetState`, return true if that happens within the time limit.
+bool waitForModelState(control::Context::Ptr const& context, state::State::StateEnum targetState, string const& note) {
+    auto waitStart = util::CLOCK::now();
+    bool success = false;
+    while (!success) {
+        auto currentStateId = context->model.getCurrentState()->getId();
+        success = currentStateId == targetState;
+        string stateMsg(note + " waitForModelState targ=" + state::State::getStateEnumStr(targetState) + " act=" + state::State::getStateEnumStr(currentStateId));
+        LDEBUG(stateMsg);
+        if (!success) {
+            auto waitTimePassed = util::CLOCK::now() - waitStart;
+            if (waitTimePassed > 1s) {
+                LERROR("waitForModelState timedOut ", stateMsg);
+                break;
+            }
+            this_thread::sleep_for(0.1s);
+        }
+    }
+    return success;
+}
+
+nlohmann::json waitForPowerSystemState(system::ComClient& client,control::PowerSystemType powType, control::PowerState targetState, string const& note) {
+    // Check that the power message was received by the client
+    // First check if it was already received, and would be found in the map.
+    string const powerSysStateId("powerSystemState");
+    string lMsg("waitForPowerSystemState key=" + powerSysStateId + " type=" + control::getPowerSystemTypeStr(powType) + " " + to_string(powType)
+            + " targ=" + control::getPowerStateStr(targetState) + " " + to_string(targetState));
+    LDEBUG(lMsg);
+    system::JsonMsgMap::JsonDeque jDeque = client.recvDequeForId(powerSysStateId, note);
+    for (auto const& js:jDeque) {
+        string jsStr = to_string(js);
+        LDEBUG(waitForPowerSystemState, jsStr);
+    }
+
+    // The most recent power state with "powerType"==powType is what is important.
+    bool found = false;
+    nlohmann::json js;
+    while (!found && !jDeque.empty()) {
+        js = jDeque.back();
+        jDeque.pop_back();
+        if (js["id"] == powerSysStateId
+                && js["powerType"] == powType
+                && js["state"] == targetState) {
+            found = true;
+            LDEBUG("found in map ", lMsg);
+        }
+    }
+    auto waitStart = util::CLOCK::now();
+    while (!found) {
+        js = client.cmdRecvId(powerSysStateId, note);
+        if (js["id"] == powerSysStateId
+                && js["powerType"] == powType
+                && js["state"] == targetState) {
+            found = true;
+            LDEBUG("found by cmdRecvId");
+        } else {
+            auto waitTimePassed = util::CLOCK::now() - waitStart;
+            if (waitTimePassed > 5s) {
+                LERROR("waitForPowerSystemState timedOut ", lMsg);
+                nlohmann::json jsEmpty;
+                return jsEmpty;
+            }
+        }
+    }
+    return js;
+}
+
+/// This is used where the test needs to wait for another iteration of the system for the
+/// status needs to be updated. It may be desirable to have the status update more quickly
+/// so using this to make it easy to locate where the tests would need to be updated.
+void shortSleep() {
+    this_thread::sleep_for(0.1s);
+}
 
 TEST_CASE("Test startup shutdown", "[CSV]") {
     LSST::m2cellcpp::util::Log::getLog().useEnvironmentLogLvl();
-    string cfgPath = LSST::m2cellcpp::system::Config::getEnvironmentCfgPath("../configs");
+    string cfgPath = system::Config::getEnvironmentCfgPath("../configs");
+    system::Config::setup(cfgPath + "unitTestCfg.yaml");
+    auto& config = system::Config::get();
 
-    LSST::m2cellcpp::simulator::SimCore::Ptr simCore(new LSST::m2cellcpp::simulator::SimCore());
-    FpgaIo::setup(simCore);
-    MotionEngine::setup();
-    Context::setup();
+    /// Start the main thread
+    control::ControlMain::setup();
+    control::ControlMain::Ptr ctMain = control::ControlMain::getPtr();
+    int argc = 1;
+    string argv0("test_startup_shutdown");
+    const char* argv[argc];
+    argv[0] = argv0.c_str();
+    ctMain->run(argc, argv);
 
-    Context::Ptr context = Context::get();
+    // Wait a few seconds for ctMain to be running
+    for (int j = 0; !ctMain->getRunning() && j < 10; ++j) {
+        sleep(1);
+    }
+    simulator::SimCore::Ptr simCore = ctMain->getSimCore();
+
+    // Start client connection.
+    system::IoContextPtr ioContext = make_shared<boost::asio::io_context>();
+    int port = config.getControlServerPort();
+    system::ComClient client(ioContext, "127.0.0.1", port);
+    int welcomeCount = client.readWelcomeMsg();
+    LDEBUG("welcomeCount=", welcomeCount);
+    REQUIRE(welcomeCount == 16);
+
+    control::Context::Ptr context = control::Context::get();
     REQUIRE(context != nullptr);
     context->model.ctrlSetup();
+    control::PowerSystem::Ptr powerSys = context->model.getPowerSystem();
 
-    REQUIRE(context->model.getCurrentState() == context->model.getState(State::STARTUPSTATE));
+    // FUTURE: TODO: put this item into the configuration (or where does it really belong?)
+    powerSys->writeCrioInterlockEnable(true);
 
-    auto newState = context->model.getState(State::IDLESTATE);
-    REQUIRE(context->model.changeState(newState));
-    REQUIRE(context->model.getCurrentState() == context->model.getState(State::IDLESTATE));
+    auto currentState = context->model.getCurrentState();
+    LINFO("currentState=", currentState->getName());
+    REQUIRE(context->model.getCurrentState() == context->model.getState(state::State::STANDBYSTATE));
+
+    int seqId = 0;
+    {
+        seqId++;
+        string note("Correct NCmdPower on comm power ");
+        note += to_string(seqId);
+        LDEBUG(note);
+        string jStr = R"({"id":"cmd_power","powerType": 2, "status": true, "sequence_id":)";
+        jStr += to_string(seqId) + " }";
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+        REQUIRE(ackJ["sequence_id"] == seqId);
+        REQUIRE(ackJ["id"] == "ack");
+        REQUIRE(finJ["sequence_id"] == seqId);
+        REQUIRE(finJ["id"] == "success");
+        REQUIRE(finJ["user_info"] == "");
+
+        // verify model state
+        bool inStandby = waitForModelState(context, state::State::STANDBYSTATE, "comm on");
+        REQUIRE(inStandby);
+
+        // verify comm power bit is on
+        shortSleep();
+        auto sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::ILC_COMM_POWER_ON) != 0);
+    }
+
+    {
+        // Power bit is on, but comm voltage should still be low,
+        // which prevents motor power from turning on.
+        string note("Fail NCmdPower on motor power");
+        note += to_string(seqId);
+        LDEBUG(note);
+        string jStr = R"({"id":"cmd_power","powerType": 1, "status": true, "sequence_id":)";
+        jStr += to_string(seqId) + " }";
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+        REQUIRE(ackJ["sequence_id"] == seqId);
+        REQUIRE(ackJ["id"] == "noack");
+        REQUIRE(finJ["sequence_id"] == seqId);
+        REQUIRE(finJ["id"] == "fail");
+        REQUIRE(finJ["user_info"] == "");
+
+        // verify power bits haven't changed
+        auto sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::ILC_COMM_POWER_ON) != 0);
+
+
+        // wait up to 5 seconds for the comm power to rise to 'ON' level voltage
+        bool onSuccess = waitForPowerState(control::PowerState::ON, powerSys->getComm(), "comm");
+        REQUIRE(onSuccess);
+        shortSleep();
+        shortSleep();
+        shortSleep();
+
+        // comm power is now on. Verify the "powerSystemState" message.
+        nlohmann::json jsPowerSystemState = waitForPowerSystemState(client, control::PowerSystemType::COMM, control::PowerState::ON, "comm on");
+        REQUIRE(jsPowerSystemState["id"] == "powerSystemState");
+        REQUIRE(jsPowerSystemState["powerType"] == control::PowerSystemType::COMM); // 2
+        REQUIRE(jsPowerSystemState["state"] == control::PowerState::ON); // 5
+        REQUIRE(jsPowerSystemState["status"] == true);
+    }
+
+    {
+        seqId++;
+        string note("Correct NCmdPower on motor power ");
+        note += to_string(seqId);
+        LDEBUG(note);
+        string jStr = R"({"id":"cmd_power","powerType": 1, "status": true, "sequence_id":)";
+        jStr += to_string(seqId) + " }";
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+        REQUIRE(ackJ["sequence_id"] == seqId);
+        REQUIRE(ackJ["id"] == "ack");
+        REQUIRE(finJ["sequence_id"] == seqId);
+        REQUIRE(finJ["id"] == "success");
+        REQUIRE(finJ["user_info"] == "");
+
+        // verify power bits are on
+        shortSleep();
+        auto sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::MOTOR_POWER_ON) != 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::ILC_COMM_POWER_ON) != 0);
+
+        // wait up to 5 seconds for the motor power to rise to 'ON' level voltage
+        bool onSuccess = waitForPowerState(control::PowerState::ON, powerSys->getMotor(), "motor");
+        REQUIRE(onSuccess);
+
+        // motor power is now on. Verify the "powerSystemState" message.
+        nlohmann::json jsPowerSystemState = waitForPowerSystemState(client, control::PowerSystemType::MOTOR, control::PowerState::ON, "motor on");
+        REQUIRE(jsPowerSystemState["id"] == "powerSystemState");
+        REQUIRE(jsPowerSystemState["powerType"] == control::PowerSystemType::MOTOR); // 1
+        REQUIRE(jsPowerSystemState["state"] == control::PowerState::ON); // 5
+        REQUIRE(jsPowerSystemState["status"] == true);
+
+        // verify model state should switch to IDLESTATE once all power is on
+        bool inIdle = waitForModelState(context, state::State::IDLESTATE, "motor on");
+        REQUIRE(inIdle);
+    }
+
+    {
+        seqId++;
+        string note("Correct NCmdPower off motor power ");
+        note += to_string(seqId);
+        LDEBUG(note);
+        string jStr = R"({"id":"cmd_power","powerType": 1, "status": false, "sequence_id":)";
+        jStr += to_string(seqId) + " }";
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+        REQUIRE(ackJ["sequence_id"] == seqId);
+        REQUIRE(ackJ["id"] == "ack");
+        REQUIRE(finJ["sequence_id"] == seqId);
+        REQUIRE(finJ["id"] == "success");
+        REQUIRE(finJ["user_info"] == "");
+
+        // verify motor power bit is off
+        shortSleep();
+        auto sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::ILC_COMM_POWER_ON) != 0);
+
+        // verify model state should switch to STANDBYSTATE once motor power starts turning off
+        bool inStandby = waitForModelState(context, state::State::STANDBYSTATE, "motor off");
+        REQUIRE(inStandby);
+
+        // wait up to 5 seconds for the motor power to fall to 'OFF' level voltage
+        bool onSuccess = waitForPowerState(control::PowerState::OFF, powerSys->getMotor(), "motor");
+        REQUIRE(onSuccess);
+
+        // motor power is now off. Verify the "powerSystemState" message.
+        nlohmann::json jsPowerSystemState = waitForPowerSystemState(client, control::PowerSystemType::MOTOR, control::PowerState::OFF, "motor off");
+        REQUIRE(jsPowerSystemState["id"] == "powerSystemState");
+        REQUIRE(jsPowerSystemState["powerType"] == control::PowerSystemType::MOTOR); // 1
+        REQUIRE(jsPowerSystemState["state"] == control::PowerState::OFF); // 2
+        REQUIRE(jsPowerSystemState["status"] == false);
+    }
+
+
+    {
+        seqId++;
+        string note("Correct NCmdPower off comm power ");
+        note += to_string(seqId);
+        LDEBUG(note);
+        string jStr = R"({"id":"cmd_power","powerType": 2, "status": false, "sequence_id":)";
+        jStr += to_string(seqId) + " }";
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+        REQUIRE(ackJ["sequence_id"] == seqId);
+        REQUIRE(ackJ["id"] == "ack");
+        REQUIRE(finJ["sequence_id"] == seqId);
+        REQUIRE(finJ["id"] == "success");
+        REQUIRE(finJ["user_info"] == "");
+
+
+        // verify comm power bit is off
+        shortSleep();
+        auto sInfo = simCore->getSysInfo();
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::MOTOR_POWER_ON) == 0);
+        REQUIRE(sInfo.outputPort.getBitAtPos(control::OutputPortBits::ILC_COMM_POWER_ON) == 0);
+
+        // verify model state
+        bool inStandby = waitForModelState(context, state::State::STANDBYSTATE, "comm off");
+        REQUIRE(inStandby);
+
+        // comm power is now on. Verify the "powerSystemState" message.
+        nlohmann::json jsPowerSystemState = waitForPowerSystemState(client, control::PowerSystemType::COMM, control::PowerState::OFF, "comm off");
+        REQUIRE(jsPowerSystemState["id"] == "powerSystemState");
+        REQUIRE(jsPowerSystemState["powerType"] == control::PowerSystemType::COMM); // 2
+        REQUIRE(jsPowerSystemState["state"] == control::PowerState::OFF); // 2
+        REQUIRE(jsPowerSystemState["status"] == false);
+    }
+
+
+    {
+        seqId++;
+        string note("NCmdSystemShutdown");
+        string jStr = R"({"id":"cmd_systemShutdown","sequence_id": )";
+        jStr += to_string(seqId) + " }";
+        LINFO(note, " ", jStr);
+        auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
+    }
+
+    // FUTURE: these should be shutdown properly elsewhere.
+    context->model.getPowerSystem()->stopTimeoutLoop();
+    control::FpgaIo::getPtr()->stopLoop();
+    control::MotionEngine::getPtr()->engineStop();
+
+    LDEBUG("Join main");
+    ctMain->join();
+
+    LDEBUG("stopping local io");
+    ioContext->stop();
+
+    LINFO("Done");
 }

--- a/tests/test_startup_shutdown.cpp
+++ b/tests/test_startup_shutdown.cpp
@@ -154,14 +154,10 @@ TEST_CASE("Test startup shutdown", "[CSV]") {
     /// Start the main thread
     control::ControlMain::setup();
     control::ControlMain::Ptr ctMain = control::ControlMain::getPtr();
-    int argc = 1;
-    string argv0("test_startup_shutdown");
-    const char* argv[argc];
-    argv[0] = argv0.c_str();
-    ctMain->run(argc, argv);
+    ctMain->run();
 
     // Wait a few seconds for ctMain to be running
-    for (int j = 0; !ctMain->getRunning() && j < 10; ++j) {
+    for (int j = 0; !ctMain->isRunning() && j < 10; ++j) {
         sleep(1);
     }
     simulator::SimCore::Ptr simCore = ctMain->getSimCore();

--- a/tests/test_startup_shutdown.cpp
+++ b/tests/test_startup_shutdown.cpp
@@ -364,6 +364,9 @@ TEST_CASE("Test startup shutdown", "[CSV]") {
         auto [ackJ, finJ] = client.cmdSendRecv(jStr, seqId, note);
     }
 
+    LDEBUG("stopping local io");
+    ioContext->stop();
+
     // FUTURE: these should be shutdown properly elsewhere.
     context->model.getPowerSystem()->stopTimeoutLoop();
     control::FpgaIo::getPtr()->stopLoop();
@@ -371,9 +374,6 @@ TEST_CASE("Test startup shutdown", "[CSV]") {
 
     LDEBUG("Join main");
     ctMain->join();
-
-    LDEBUG("stopping local io");
-    ioContext->stop();
 
     LINFO("Done");
 }


### PR DESCRIPTION
Added the cmd_power command. This includes logic to keep motor power from being on without ILC com power being on. For testing, I moved main into a separate thread so the testing thread can be the client. This basically makes test_startup_shutdown.cpp an integration test using the simulator in place of the hardware.